### PR TITLE
feat: add dynamic agent dispatch and command execution to Claude Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Agentikit Plugins
 
-Platform-specific plugins for the [Agentikit](https://github.com/itlackey/agentikit) CLI. Both packages are thin wrappers that call the `akm` CLI to **search** and **show** extension assets from a stash directory.
+Platform-specific plugins for the [Agentikit](https://github.com/itlackey/agentikit) CLI. Both packages wrap the `akm` CLI to **search**, **show**, **dispatch agents**, and **execute commands** from a stash directory.
 
 ## Packages
 
 ### agentikit-claude
 
-Claude Code plugin providing a skill and slash commands.
+Claude Code plugin providing a skill for stash asset management, dynamic agent dispatch, and command execution.
 
 Add the marketplace and install the plugin:
 
@@ -27,6 +27,8 @@ claude plugin install agentikit@agentikit-plugins
 
 Provides:
 - **Agentikit Skill** — Claude automatically uses the akm CLI when you ask about stash assets
+- **Dynamic agent dispatch** — Claude fetches agent definitions from the stash and spawns subagents on the fly with the agent's prompt, tool constraints, and task
+- **Command execution** — Claude resolves command templates, renders argument placeholders (`$ARGUMENTS`, `$1`, `$2`), and executes the result
 
 ### agentikit-opencode
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,6 +1,6 @@
 # agentikit-claude
 
-Claude Code plugin for the [Agentikit](https://github.com/itlackey/agentikit) CLI. Provides a skill that teaches Claude to **search** and **show** extension assets from a stash directory.
+Claude Code plugin for the [Agentikit](https://github.com/itlackey/agentikit) CLI. Provides a skill that teaches Claude to **search**, **show**, **dispatch agents**, and **execute commands** from a stash directory.
 
 ## Installation
 
@@ -25,7 +25,36 @@ claude plugin install agentikit@agentikit-plugins
 
 - **Agentikit Skill** — Claude automatically uses the `akm` CLI when you ask about stash assets
 
-The skill teaches Claude the full CLI workflow: `akm init`, `akm index`, `akm search`, and `akm show`.
+The skill teaches Claude to:
+
+- **Search & show** assets via `akm search` and `akm show`
+- **Dispatch stash agents** dynamically — Claude fetches an agent's markdown definition (prompt, toolPolicy, modelHint) and spawns a subagent on the fly with those instructions embedded
+- **Execute stash commands** — Claude resolves a command template, renders `$ARGUMENTS`/`$1`/`$2` placeholders, and executes the result
+
+### Dynamic agent dispatch
+
+Ask Claude to dispatch any agent from your stash:
+
+```
+Dispatch the coach agent to review src/auth.ts
+```
+
+Claude will resolve the agent ref, fetch its prompt and metadata via `akm show`, compose a subagent with the agent's persona, and execute the task autonomously.
+
+### Command execution
+
+Ask Claude to run any command template from your stash:
+
+```
+Run the review command on src/main.ts --strict
+```
+
+Claude will fetch the command template, render argument placeholders, and execute the result.
+
+### Limitations vs OpenCode plugin
+
+- **modelHint** is advisory only — Claude Code does not support per-subagent model selection
+- **toolPolicy** is embedded as natural-language guidance in the subagent prompt, not enforced at the runtime level
 
 ## Prerequisites
 

--- a/claude/skills/agentikit/SKILL.md
+++ b/claude/skills/agentikit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentikit
-description: Search and show extension assets from an Agentikit stash directory. Use when the user wants to find tools, skills, commands, agents, or knowledge in their stash, or view asset contents.
+description: Search, show, dispatch agents, and execute commands from an Agentikit stash directory. Use when the user wants to find or use tools, skills, commands, agents, or knowledge in their stash.
 ---
 
 # Agentikit Stash
@@ -73,3 +73,136 @@ Configurable keys: `semanticSearch`, `additionalStashDirs`, `embedding`, `llm`.
 4. Inspect a result: `akm show <ref>`
 
 All output is JSON for easy parsing.
+
+## Dispatching Stash Agents
+
+You can dynamically spawn a stash agent to work on a task. The agent's prompt, tool constraints, and model preferences are defined in its markdown file and loaded at runtime.
+
+### Agent payload shape
+
+`akm show <agent-ref>` returns JSON:
+
+```json
+{
+  "type": "agent",
+  "name": "coach.md",
+  "path": "/stash/agents/coach.md",
+  "description": "Code review coach",
+  "prompt": "You are a code review coach. Focus on ...",
+  "toolPolicy": { "read": true, "edit": false, "bash": false },
+  "modelHint": "anthropic/claude-sonnet-4-5-20250514"
+}
+```
+
+- `prompt` (required) — the agent's system instructions
+- `toolPolicy` (optional) — boolean flags indicating which tool categories the agent should use
+- `modelHint` (optional) — preferred `provider/model` (advisory only in Claude Code)
+
+### Dispatch workflow
+
+When the user asks you to dispatch, run, or use a stash agent:
+
+1. **Resolve the ref.** If the user gives a direct ref (e.g. `agent:coach.md`), use it. Otherwise search:
+   ```bash
+   akm search "<query>" --type agent --limit 1
+   ```
+   Extract `openRef` from the first hit in the `hits` array.
+
+2. **Fetch the agent payload:**
+   ```bash
+   akm show <ref>
+   ```
+   Parse the JSON. Verify `type` is `"agent"` and `prompt` is non-empty. If validation fails, inform the user.
+
+3. **Compose the subagent prompt.** Build a prompt that embeds the stash agent's persona and the user's task:
+
+   ```
+   <agent-persona>
+   {value of the "prompt" field from akm show}
+   </agent-persona>
+
+   <tool-constraints>
+   {render toolPolicy as natural language, e.g.:
+    - "You may read files but must NOT edit files or run shell commands."
+    - If toolPolicy is absent, omit this section.}
+   </tool-constraints>
+
+   Task: {the user's task description}
+   ```
+
+4. **Spawn the subagent** using the Agent tool with `subagent_type: "general-purpose"` and the composed prompt.
+
+5. **Report results** to the user. If `modelHint` was present, note that Claude Code does not support per-subagent model selection so it was not enforced.
+
+### Example
+
+User: "Dispatch the coach agent to review src/auth.ts"
+
+You would run:
+```bash
+akm show agent:coach.md
+```
+Then spawn a general-purpose subagent with the coach's prompt embedded, tasked with reviewing `src/auth.ts`.
+
+## Executing Stash Commands
+
+You can execute stash command templates by resolving them, rendering argument placeholders, and running the result.
+
+### Command payload shape
+
+`akm show <command-ref>` returns JSON:
+
+```json
+{
+  "type": "command",
+  "name": "review.md",
+  "path": "/stash/commands/review.md",
+  "description": "Review a file for issues",
+  "template": "Review $1 for bugs, security issues, and code quality. Focus on: $ARGUMENTS"
+}
+```
+
+- `template` (required) — text with `$ARGUMENTS` (full arg string) and positional `$1`, `$2`, ... placeholders
+
+### Template rendering rules
+
+Given arguments `"src/main.ts" --strict`:
+- `$ARGUMENTS` → `"src/main.ts" --strict` (the full raw argument string)
+- `$1` → `src/main.ts` (first positional arg, quotes stripped)
+- `$2` → `--strict` (second positional arg)
+- Positional args are split by whitespace. Quoted strings (`"double"`, `'single'`, `` `backtick` ``) are treated as a single argument with quotes removed.
+
+### Execution workflow
+
+When the user asks you to run or execute a stash command:
+
+1. **Resolve the ref.** If the user gives a direct ref (e.g. `command:review.md`), use it. Otherwise search:
+   ```bash
+   akm search "<query>" --type command --limit 1
+   ```
+   Extract `openRef` from the first hit.
+
+2. **Fetch the command payload:**
+   ```bash
+   akm show <ref>
+   ```
+   Parse the JSON. Verify `type` is `"command"` and `template` is non-empty.
+
+3. **Render the template.** Replace `$ARGUMENTS` with the full argument string and `$1`, `$2`, etc. with the corresponding positional arguments.
+
+4. **Execute the rendered text:**
+   - If it is a shell command (starts with a known CLI tool, contains pipes, redirects, etc.) → execute with the Bash tool.
+   - If it is a natural-language instruction or multi-step task → execute with the Agent tool using `subagent_type: "general-purpose"`.
+   - If ambiguous, ask the user.
+
+5. **Report results** to the user.
+
+### Example
+
+User: "Run the review command on src/main.ts with --strict"
+
+You would run:
+```bash
+akm show command:review.md
+```
+Then render the template replacing `$1` with `src/main.ts` and `$ARGUMENTS` with `src/main.ts --strict`, and execute the resulting instruction.


### PR DESCRIPTION
Enhance the agentikit skill to teach Claude how to dynamically spawn
stash agents and execute command templates, bringing parity with the
OpenCode plugin's dispatch_agent and exec_cmd capabilities.

https://claude.ai/code/session_01VqwNwUnnNVw9XHqRbmf2X9