### PR TITLE
Add compound-engineering loop: auto-curate, feedback, and memory capture

### DIFF
--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,6 +1,6 @@
 # akm-opencode
 
-OpenCode plugin for the [AKM](https://github.com/itlackey/akm) CLI. Registers tools that let your AI agent **search**, **show**, and **manage** extension assets from stash directories and registries.
+OpenCode plugin for the [AKM](https://github.com/itlackey/akm) CLI. Registers tools that let your AI agent **search**, **show**, and **manage** extension assets from stash directories and registries — plus **agentic hooks** that auto-load relevant assets into each turn, record feedback when assets are used, and harvest session memories so the stash improves with every session.
 
 ## Installation
 
@@ -33,8 +33,43 @@ Add to your OpenCode config (`opencode.json`):
 | `akm_run` | Execute a stash script using its `run` field |
 | `akm_sources` | Backward-compatible alias that lists configured AKM sources |
 | `akm_upgrade` | Check for or install akm CLI updates |
+| `akm_curate` | Curate the stash for a task or topic and return ranked matches the agent can use |
+| `akm_evolve` | Dispatch the AKM curator agent to review recent session activity and propose stash improvements |
 
-The plugin also uses the OpenCode `chat.message` and `tool.execute.after` hooks to record user/system feedback activity and memory usage in OpenCode app logs when relevant.
+## Compound-engineering hooks
+
+The plugin subscribes to OpenCode lifecycle events so AKM participates in the
+session loop instead of waiting to be called. Every hook is non-blocking and
+fails silently when `akm` is not on PATH — the TUI is never affected.
+
+| Event | What happens |
+| --- | --- |
+| **`session.created`** (event hook) | Warms the stash index in the background and caches `akm hints` for the next system transform so the agent knows the CLI surface area at turn 0. |
+| **`chat.message`** | Runs `akm curate "<prompt>"` on each user message (prompts shorter than `AKM_CURATE_MIN_CHARS` are skipped). The top matches are stored for injection. Memory intents (prompts mentioning "remember" / "memory") are tracked in the session buffer. |
+| **`experimental.chat.system.transform`** | Appends the cached hints (once per session) and the curated context (once per turn) to the model's system prompt so the agent sees relevant stash assets before answering. |
+| **`tool.execute.after`** (`akm_*` tools) | Logs asset usage, accumulates refs into the session buffer, and records `akm feedback <ref> --positive` / `--negative` automatically based on whether the tool succeeded or failed. Never recurses into `akm_feedback` and skips `memory:` refs. |
+| **`stop`** / **`session.idle`** / **`session.compacted`** / **`session.deleted`** | Flushes the per-session buffer into a `memory:opencode-session-YYYYMMDD-<sid>` memory so every meaningful session contributes durable context for future searches. Requires at least two observations before persisting. |
+
+### Environment overrides
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AKM_AUTO_CURATE` | `1` | Set to `0` to disable automatic `akm curate` on user messages. |
+| `AKM_AUTO_FEEDBACK` | `1` | Set to `0` to disable automatic `akm feedback` on tool success/failure. |
+| `AKM_AUTO_HINTS` | `1` | Set to `0` to skip injecting `akm hints` at session start. |
+| `AKM_AUTO_MEMORY` | `1` | Set to `0` to disable automatic session-summary memories. |
+| `AKM_CURATE_LIMIT` | `5` | Max curated results injected into context per prompt. |
+| `AKM_CURATE_MIN_CHARS` | `16` | Minimum prompt length before curation runs. |
+| `AKM_CURATE_TIMEOUT` | `8` | Wall-clock seconds for `akm` invocations inside hooks. |
+
+### Curator agent
+
+`akm_evolve` dispatches a child OpenCode session running a built-in curator
+prompt that reviews recent AKM activity (OpenCode app logs, session-summary
+memories, live stash) and produces a prioritized action list: hot assets to
+promote, cold ones to investigate, coverage gaps to draft, duplicates to
+consolidate. The curator never applies destructive changes without explicit
+user approval.
 
 ### Registry discovery
 

--- a/opencode/index.ts
+++ b/opencode/index.ts
@@ -5,6 +5,71 @@ import path from "node:path"
 let resolvedAkmCommand = "akm"
 const autoInstallPackageRef = "akm-cli@latest"
 
+const AKM_AUTO_FEEDBACK = (process.env.AKM_AUTO_FEEDBACK ?? "1") !== "0"
+const AKM_AUTO_MEMORY = (process.env.AKM_AUTO_MEMORY ?? "1") !== "0"
+const AKM_AUTO_CURATE = (process.env.AKM_AUTO_CURATE ?? "1") !== "0"
+const AKM_AUTO_HINTS = (process.env.AKM_AUTO_HINTS ?? "1") !== "0"
+const AKM_CURATE_LIMIT = Math.max(1, Number(process.env.AKM_CURATE_LIMIT ?? "5") || 5)
+const AKM_CURATE_MIN_CHARS = Math.max(1, Number(process.env.AKM_CURATE_MIN_CHARS ?? "16") || 16)
+const AKM_CURATE_TIMEOUT_MS = Math.max(1_000, (Number(process.env.AKM_CURATE_TIMEOUT ?? "8") || 8) * 1_000)
+
+// Per-session state that drives the compound-engineering loop.
+// These maps are keyed by OpenCode sessionID.
+const sessionHints = new Map<string, string>()
+const sessionCurated = new Map<string, string>()
+type SessionBufferEntry = {
+  timestamp: string
+  kind: "memory-intent" | "tool-ref"
+  toolName?: string
+  ref?: string
+  status?: "positive" | "negative" | "unknown"
+  note?: string
+}
+const sessionBuffer = new Map<string, SessionBufferEntry[]>()
+const sessionMemoryCaptured = new Set<string>()
+
+// Asset-ref grammar matching the stash skill: [origin//]type:name
+const AKM_REF_PATTERN = /(?:[A-Za-z0-9@._+/-]+\/\/)?(?:skill|command|agent|knowledge|memory|script):[A-Za-z0-9._/\-]+/g
+
+const CURATOR_AGENT_PROMPT = `You are the AKM curator — a compound-engineering agent that keeps the user's AKM stash improving every time the main agent finishes a task.
+
+Inputs you should inspect:
+1. OpenCode app logs that include the "akm-opencode" service (feedback, memory, tool invocations).
+2. Session-summary memories named memory:opencode-session-*.
+3. The live stash: call akm_list, akm_search "" --limit 50, and akm_show <ref>.
+
+Signals to act on:
+- Hot refs: assets repeatedly appearing in positive tool outcomes. Call akm_feedback <ref> positive --note "curator: consistently useful" to reinforce.
+- Cold refs: assets tied to failures or user complaints. Record akm_feedback <ref> negative --note "<excerpt>" and open the asset for review.
+- Missing coverage: recurring user prompts with no matching asset. Draft a new skill, command, or knowledge doc in the working stash and reindex with akm_index.
+- Duplicates / drift: near-identical descriptions or overlapping responsibilities. Propose a consolidation.
+- Stale memories: session summaries that never get recalled. Propose akm_remove memory:<name> once distilled into a durable knowledge doc.
+
+Rules of engagement:
+- Never apply destructive changes without explicit user approval.
+- Report findings as a prioritized action list of concrete akm_* tool calls the user can run.
+- Prefer small, reversible edits: promote via positive feedback, draft a candidate skill, or clone and tweak.
+- When drafting new assets, write them into the working stash directory (akm_config get stashDir) under skills/, commands/, agents/, knowledge/, or scripts/. Call akm_index when finished.
+- When finished, persist your own summary with akm_remember (name: curator-run-<timestamp>) so the next curator run can build on yours.
+
+Output shape: end every run with a markdown report that has these sections:
+
+## Hot assets (promote)
+- <ref> — why it helped — command to run
+
+## Cold assets (investigate)
+- <ref> — failure signal — proposed fix
+
+## Coverage gaps
+- <theme> — proposed asset (type, name, one-line description)
+
+## Duplicates / drift
+- <ref a> vs <ref b> — consolidation proposal
+
+## Housekeeping
+- stale memories, reindex needs, config tweaks
+`
+
 type LogLevel = "debug" | "info" | "warn" | "error"
 
 type LogCapableClient = {
@@ -60,6 +125,209 @@ async function writePluginLog(client: LogCapableClient, level: LogLevel, message
   } catch {
     // Avoid breaking the TUI if logging itself fails.
   }
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function addBufferEntry(sessionID: string | undefined, entry: Omit<SessionBufferEntry, "timestamp">) {
+  if (!sessionID) return
+  const buf = sessionBuffer.get(sessionID) ?? []
+  buf.push({ timestamp: nowIso(), ...entry })
+  sessionBuffer.set(sessionID, buf)
+}
+
+// Synchronous CLI invocation used by the lifecycle hooks — the plugin host does
+// not await these in a hot path, but we still cap execution time so a slow
+// stash never wedges the session loop.
+function runCliSyncRaw(args: string[], timeoutMs: number): { ok: true; stdout: string } | { ok: false; error: string } {
+  const command = resolveAkmCommand()
+  if (typeof command !== "string") return { ok: false, error: command.error }
+  try {
+    const stdout = execFileSync(command, args, {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return { ok: true, stdout }
+  } catch (error: unknown) {
+    return { ok: false, error: formatCliError(error) }
+  }
+}
+
+function runCurateForPrompt(text: string): string | null {
+  if (!text || text.length < AKM_CURATE_MIN_CHARS) return null
+  const result = runCliSyncRaw(
+    [
+      "--for-agent",
+      "--format",
+      "text",
+      "--detail",
+      "summary",
+      "-q",
+      "curate",
+      text,
+      "--limit",
+      String(AKM_CURATE_LIMIT),
+    ],
+    AKM_CURATE_TIMEOUT_MS,
+  )
+  if (!result.ok) return null
+  const body = result.stdout.trim()
+  return body || null
+}
+
+function runHintsForSession(): string | null {
+  const result = runCliSyncRaw(["--format", "text", "-q", "hints"], AKM_CURATE_TIMEOUT_MS)
+  if (!result.ok) return null
+  const body = result.stdout.trim()
+  return body || null
+}
+
+function warmIndexInBackground(): void {
+  const command = resolveAkmCommand()
+  if (typeof command !== "string") return
+  try {
+    // Fire and forget — execSync with a timeout would block, so spawn via the
+    // shell and detach. Errors here are never surfaced to the session.
+    execSync(`${JSON.stringify(command)} index >/dev/null 2>&1 &`, { timeout: 2_000 })
+  } catch {
+    // Intentionally ignore — warming is best-effort.
+  }
+}
+
+function recordFeedbackSync(ref: string, sentiment: "positive" | "negative", note: string): boolean {
+  const result = runCliSyncRaw(
+    [
+      "--format",
+      "json",
+      "-q",
+      "feedback",
+      ref,
+      sentiment === "positive" ? "--positive" : "--negative",
+      "--note",
+      note,
+    ],
+    AKM_CURATE_TIMEOUT_MS,
+  )
+  return result.ok
+}
+
+function captureSessionMemory(sessionID: string, reason: string): string | null {
+  if (!AKM_AUTO_MEMORY) return null
+  if (!sessionID) return null
+  if (sessionMemoryCaptured.has(sessionID)) return null
+  const entries = sessionBuffer.get(sessionID) ?? []
+  // Require at least two observations before persisting — single events are noise.
+  if (entries.length < 2) {
+    sessionBuffer.delete(sessionID)
+    return null
+  }
+
+  const lines: string[] = []
+  lines.push(`# Session summary (${nowIso()})`)
+  lines.push(`Reason: ${reason}`)
+  lines.push(`Session: ${sessionID}`)
+  lines.push("")
+  for (const entry of entries) {
+    if (entry.kind === "memory-intent") {
+      lines.push(`## ${entry.timestamp} — user memory intent`)
+      if (entry.note) lines.push(entry.note)
+      lines.push("")
+    } else {
+      lines.push(`## ${entry.timestamp} — ${entry.toolName ?? "tool"} ${entry.status ?? "unknown"}`)
+      if (entry.ref) lines.push(`- ref: ${entry.ref}`)
+      if (entry.note) lines.push(`- note: ${entry.note}`)
+      lines.push("")
+    }
+  }
+  const body = lines.join("\n")
+
+  const dateTag = new Date().toISOString().replace(/[-:]/g, "").slice(0, 8)
+  const shortSid = sessionID.replace(/[^A-Za-z0-9._-]/g, "").slice(0, 8) || "session"
+  const name = `opencode-session-${dateTag}-${shortSid}`
+
+  const command = resolveAkmCommand()
+  if (typeof command !== "string") {
+    sessionMemoryCaptured.add(sessionID)
+    sessionBuffer.delete(sessionID)
+    return null
+  }
+  try {
+    execFileSync(command, ["--format", "json", "-q", "remember", "--name", name, "--force"], {
+      encoding: "utf8",
+      timeout: AKM_CURATE_TIMEOUT_MS * 2,
+      input: body,
+    })
+    sessionMemoryCaptured.add(sessionID)
+    sessionBuffer.delete(sessionID)
+    return `memory:${name}`
+  } catch {
+    sessionMemoryCaptured.add(sessionID)
+    sessionBuffer.delete(sessionID)
+    return null
+  }
+}
+
+function extractToolRefs(toolName: string, args: Record<string, unknown>, output: unknown): string[] {
+  const refs = new Set<string>()
+  const addMatches = (value: unknown) => {
+    if (typeof value !== "string") return
+    const matches = value.match(AKM_REF_PATTERN)
+    if (matches) for (const ref of matches) refs.add(ref)
+  }
+
+  for (const key of ["ref", "package_ref"]) {
+    addMatches((args as Record<string, unknown>)[key])
+  }
+
+  if (output && typeof output === "object") {
+    const o = output as Record<string, unknown>
+    addMatches(o.ref)
+    if (Array.isArray(o.hits)) {
+      for (const hit of o.hits) {
+        if (hit && typeof hit === "object") addMatches((hit as Record<string, unknown>).ref)
+      }
+    }
+    if (Array.isArray(o.assetHits)) {
+      for (const hit of o.assetHits) {
+        if (hit && typeof hit === "object") addMatches((hit as Record<string, unknown>).ref)
+      }
+    }
+    if (toolName === "akm_remember" && typeof o.ref === "string") addMatches(o.ref)
+  }
+
+  return [...refs]
+}
+
+const AKM_HINTS_PREFIX = [
+  "# AKM is available in this session",
+  "",
+  "You have an AKM stash on this machine. Before writing anything from scratch, call `akm_search` or `akm_curate` to see if the stash already covers it. Record `akm_feedback <ref> positive|negative` whenever an asset materially helps or misses, and use `akm_remember` to persist durable learnings so future sessions inherit them.",
+].join("\n")
+
+const AKM_CURATED_HEADER = "# AKM stash — assets relevant to this prompt"
+const AKM_CURATED_TAIL = "\n\nTip: call `akm_show <ref>` to fetch full content, and record `akm_feedback <ref> positive|negative` once you know whether the asset helped."
+
+function extractSessionIdFromEvent(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined
+  const p = payload as Record<string, unknown>
+  const candidates = [
+    p.sessionID,
+    p.session_id,
+    p.session,
+    (p.session as Record<string, unknown> | undefined)?.id,
+    (p.properties as Record<string, unknown> | undefined)?.sessionID,
+    (p.properties as Record<string, unknown> | undefined)?.session_id,
+    (p.properties as Record<string, unknown> | undefined)?.id,
+    (p.info as Record<string, unknown> | undefined)?.id,
+    (p.info as Record<string, unknown> | undefined)?.sessionID,
+  ]
+  for (const value of candidates) {
+    if (typeof value === "string" && value) return value
+  }
+  return undefined
 }
 
 function getCommandStatus(command: string): "ok" | "missing" | "error" {
@@ -539,11 +807,99 @@ type PluginClient = {
 export const AkmPlugin: Plugin = async ({ client }) => {
   await ensureLatestAkmInstalled(client as unknown as LogCapableClient)
 
+  const logClient = client as unknown as LogCapableClient
+
   return {
+    // Events cover the lifecycle boundaries that Claude Code exposes as
+    // SessionStart / Stop / PreCompact. We use them to warm the stash, capture
+    // hints for the next system transform, and flush per-session memories.
+    event: async ({ event }: { event: { type: string; properties?: unknown } }) => {
+      try {
+        const type = event?.type
+        if (!type) return
+        const sid = extractSessionIdFromEvent(event) ?? extractSessionIdFromEvent((event as { properties?: unknown }).properties)
+        if (type === "session.created" || type === "session.updated") {
+          if (!sid) return
+          if (!AKM_AUTO_HINTS) return
+          if (sessionHints.has(sid)) return
+          warmIndexInBackground()
+          const hints = runHintsForSession()
+          if (hints) sessionHints.set(sid, hints)
+        } else if (type === "session.compacted" || type === "session.idle" || type === "session.deleted") {
+          if (!sid) return
+          const captured = captureSessionMemory(sid, type)
+          if (captured) {
+            await writePluginLog(logClient, "info", "AKM session memory captured", {
+              subsystem: "memory",
+              actor: "system",
+              sessionID: sid,
+              reason: type,
+              ref: captured,
+            })
+          }
+          // Drop per-session state so a re-created session does not inherit
+          // stale hints/curation.
+          if (type === "session.deleted") {
+            sessionHints.delete(sid)
+            sessionCurated.delete(sid)
+            sessionMemoryCaptured.delete(sid)
+            sessionBuffer.delete(sid)
+          }
+        }
+      } catch {
+        // Lifecycle hooks must never throw into the TUI.
+      }
+    },
+    // Stop is the closest analogue to Claude's Stop/SubagentStop — the user or
+    // agent halted the active run. Flush the session buffer so learnings are
+    // preserved even if the session.idle event does not fire.
+    stop: async (input: unknown) => {
+      try {
+        const sid = extractSessionIdFromEvent(input)
+        if (!sid) return
+        const captured = captureSessionMemory(sid, "stop")
+        if (captured) {
+          await writePluginLog(logClient, "info", "AKM session memory captured", {
+            subsystem: "memory",
+            actor: "system",
+            sessionID: sid,
+            reason: "stop",
+            ref: captured,
+          })
+        }
+      } catch {
+        // Best-effort only.
+      }
+    },
+    // experimental.chat.system.transform is how OpenCode exposes the
+    // additionalContext channel. We append the cached hints (once per session)
+    // and the curated assets (once per turn) so the next LLM call sees them.
+    "experimental.chat.system.transform": async (
+      input: { sessionID?: string; session_id?: string } | undefined,
+      output: { system?: string[] } | undefined,
+    ) => {
+      try {
+        if (!output || !Array.isArray(output.system)) return
+        const sid = extractSessionIdFromEvent(input) ?? ""
+        const hints = sid ? sessionHints.get(sid) : undefined
+        if (hints) {
+          output.system.push(`${AKM_HINTS_PREFIX}\n\n${hints}`)
+          // Only inject hints on the first transform of the session.
+          sessionHints.delete(sid)
+        }
+        const curated = sid ? sessionCurated.get(sid) : undefined
+        if (curated) {
+          output.system.push(`${AKM_CURATED_HEADER}\n${curated}${AKM_CURATED_TAIL}`)
+          sessionCurated.delete(sid)
+        }
+      } catch {
+        // Never break the turn because of a transform failure.
+      }
+    },
     "chat.message": async (input, output) => {
       const text = extractText(output.parts).trim()
       if (!text) return
-      await writePluginLog(client as unknown as LogCapableClient, "info", "AKM user feedback recorded", {
+      await writePluginLog(logClient, "info", "AKM user feedback recorded", {
         subsystem: "feedback",
         actor: "user",
         sessionID: input.sessionID,
@@ -551,6 +907,22 @@ export const AkmPlugin: Plugin = async ({ client }) => {
         agent: input.agent,
         text: truncateLogText(text),
       })
+
+      // Compound-engineering loop: on every user message, curate the stash and
+      // stash the result so experimental.chat.system.transform can inject it.
+      if (AKM_AUTO_CURATE && input.sessionID) {
+        const curated = runCurateForPrompt(text)
+        if (curated) sessionCurated.set(input.sessionID, curated)
+      }
+
+      // Track explicit memory intents so capture-memory has something durable
+      // to flush when the session ends.
+      if (/\b(remember|memory|memories)\b/i.test(text)) {
+        addBufferEntry(input.sessionID, {
+          kind: "memory-intent",
+          note: truncateLogText(text, 500),
+        })
+      }
     },
     "tool.execute.after": async (input, output) => {
       if (!input.tool.startsWith("akm_")) return
@@ -560,7 +932,7 @@ export const AkmPlugin: Plugin = async ({ client }) => {
 
       const feedback = classifyToolFeedback(parsed)
       if (feedback) {
-        await writePluginLog(client as unknown as LogCapableClient, feedback === "negative" ? "warn" : "info", "AKM system feedback recorded", {
+        await writePluginLog(logClient, feedback === "negative" ? "warn" : "info", "AKM system feedback recorded", {
           subsystem: "feedback",
           actor: "system",
           feedback,
@@ -574,13 +946,45 @@ export const AkmPlugin: Plugin = async ({ client }) => {
 
       const memoryRefs = extractMemoryRefs(input.tool, input.args as Record<string, unknown>, parsed)
       if (memoryRefs.length > 0) {
-        await writePluginLog(client as unknown as LogCapableClient, "info", "AKM memory usage recorded", {
+        await writePluginLog(logClient, "info", "AKM memory usage recorded", {
           subsystem: "memory",
           toolName: input.tool,
           sessionID: input.sessionID,
           callID: input.callID,
           refs: memoryRefs,
         })
+      }
+
+      // Auto-feedback + session buffering: record every asset ref the tool
+      // touched so the stash ranking improves over time and so Stop/Compact
+      // has material to flush into a session summary memory.
+      const allRefs = extractToolRefs(input.tool, input.args as Record<string, unknown>, parsed)
+      if (allRefs.length > 0 && input.sessionID) {
+        for (const ref of allRefs) {
+          addBufferEntry(input.sessionID, {
+            kind: "tool-ref",
+            toolName: input.tool,
+            ref,
+            status: feedback ?? "unknown",
+          })
+        }
+      }
+
+      if (
+        AKM_AUTO_FEEDBACK
+        && feedback
+        && input.tool !== "akm_feedback"
+        && allRefs.length > 0
+      ) {
+        const note = feedback === "positive"
+          ? `opencode auto: ${input.tool} succeeded`
+          : `opencode auto: ${input.tool} failed`
+        for (const ref of allRefs) {
+          // Memories do not accept feedback in the current CLI.
+          if (ref.startsWith("memory:")) continue
+          const ok = recordFeedbackSync(ref, feedback, note)
+          if (!ok) break
+        }
       }
     },
     tool: {
@@ -759,6 +1163,79 @@ export const AkmPlugin: Plugin = async ({ client }) => {
         const args = ["feedback", ref, sentiment === "positive" ? "--positive" : "--negative"]
         if (note) args.push("--note", note)
         return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_feedback" })
+      },
+    }),
+    akm_curate: tool({
+      description: "Curate stash assets for a task or topic. Returns the top matches as a ranked list so the agent can inspect and use them.",
+      args: {
+        query: tool.schema.string().describe("Task, topic, or natural-language description of what you want to do."),
+        limit: tool.schema.number().optional().describe("Maximum number of curated matches to return. Defaults to 6."),
+        detail: tool.schema.enum(["summary", "normal", "full"]).optional().describe("Detail level for each match. Defaults to 'summary'."),
+      },
+      async execute({ query, limit, detail }) {
+        const args = [
+          "--for-agent",
+          "--format",
+          "text",
+          "--detail",
+          detail ?? "summary",
+          "-q",
+          "curate",
+          query,
+          "--limit",
+          String(limit ?? 6),
+        ]
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_curate" })
+      },
+    }),
+    akm_evolve: tool({
+      description: "Dispatch the AKM curator agent to review recent session activity and propose stash improvements (promote hot assets, flag cold ones, draft missing coverage).",
+      args: {
+        focus: tool.schema.string().optional().describe("Optional focus area or theme to weight the review toward."),
+        dispatch_agent: tool.schema.string().optional().describe("OpenCode agent to run the curator with. Defaults to 'general'."),
+        as_subtask: tool.schema.boolean().optional().describe("Run in a child session with parent context. Defaults to true."),
+      },
+      async execute({ focus, dispatch_agent, as_subtask }, context) {
+        const useSubtask = as_subtask ?? true
+        const targetAgent = dispatch_agent ?? "general"
+        const targetSession = await ensureTargetSessionID({
+          useSubtask,
+          context: { sessionID: context.sessionID, directory: context.directory },
+          title: "akm:curator",
+          client: client as unknown as PluginClient,
+        })
+        if (!targetSession.ok) return JSON.stringify(targetSession)
+
+        const task = focus && focus.trim()
+          ? `Review recent AKM activity with an emphasis on: ${focus.trim()}. Produce the prioritized action list described in the system prompt.`
+          : "Review recent AKM activity and produce the prioritized action list described in the system prompt."
+
+        const promptResponse = await client.session.prompt({
+          query: { directory: context.directory },
+          path: { id: targetSession.sessionID },
+          body: {
+            agent: targetAgent,
+            system: CURATOR_AGENT_PROMPT,
+            parts: [{ type: "text", text: task }],
+          },
+        })
+
+        if (promptResponse.error || !promptResponse.data) {
+          const reason = promptResponse.error ? JSON.stringify(promptResponse.error) : "empty response"
+          return JSON.stringify({
+            ok: false,
+            error: `Failed to dispatch curator: ${reason}`,
+          })
+        }
+
+        return JSON.stringify({
+          ok: true,
+          dispatchAgent: targetAgent,
+          usedSubtask: useSubtask,
+          sessionID: targetSession.sessionID,
+          focus: focus ?? null,
+          text: extractText(promptResponse.data.parts),
+        })
       },
     }),
     akm_agent: tool({

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -2,7 +2,7 @@
   "name": "akm-opencode",
   "version": "0.4.0",
   "type": "module",
-  "description": "OpenCode plugin for AKM - search and show extension assets via the akm CLI.",
+  "description": "OpenCode plugin for AKM - search, show, and manage extension assets via the akm CLI, with agentic hooks that auto-load relevant stash assets, record feedback, and harvest session memories so the stash improves every session.",
   "keywords": [
     "opencode",
     "opencode-ai",

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -82,8 +82,17 @@ describe("akm-opencode plugin", () => {
       expect(toolNames).toContain("akm_run")
       expect(toolNames).toContain("akm_sources")
       expect(toolNames).toContain("akm_upgrade")
+      expect(toolNames).toContain("akm_curate")
+      expect(toolNames).toContain("akm_evolve")
       expect(toolNames).not.toContain("akm_submit")
-      expect(toolNames).toHaveLength(17)
+      expect(toolNames).toHaveLength(19)
+    })
+
+    it("returns lifecycle hooks for the compound-engineering loop", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      expect(hooks.event).toBeDefined()
+      expect(hooks.stop).toBeDefined()
+      expect(hooks["experimental.chat.system.transform"]).toBeDefined()
     })
   })
 
@@ -457,6 +466,62 @@ describe("akm-opencode plugin", () => {
       )
     })
 
+    it("akm_curate shells out to 'akm curate' with for-agent flags", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_curate.execute(
+        { query: "deploy the app", limit: 4 } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        [
+          "--for-agent",
+          "--format",
+          "text",
+          "--detail",
+          "summary",
+          "-q",
+          "curate",
+          "deploy the app",
+          "--limit",
+          "4",
+          "--format",
+          "json",
+        ],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_evolve dispatches the curator prompt through a child session", async () => {
+      const client = createMockClient()
+      const hooks = await AkmPlugin(createPluginInput({ client: client as any }))
+      const result = await hooks.tool!.akm_evolve.execute(
+        { focus: "release workflow" } as any,
+        {
+          sessionID: "parent-session-1",
+          directory: "/tmp/test-project",
+          worktree: "/tmp/test-project",
+          agent: "build",
+          abort: new AbortController().signal,
+          metadata: () => {},
+          ask: async () => {},
+        } as any,
+      )
+
+      const parsed = JSON.parse(result)
+      expect(parsed.ok).toBe(true)
+      expect(parsed.sessionID).toBe("child-session-1")
+      expect(parsed.dispatchAgent).toBe("general")
+      expect(parsed.focus).toBe("release workflow")
+      expect(client.session.create).toHaveBeenCalledWith({
+        query: { directory: "/tmp/test-project" },
+        body: { parentID: "parent-session-1", title: "akm:curator" },
+      })
+      const promptArgs = (client.session.prompt as any).mock.calls[0][0]
+      expect(promptArgs.body.system).toContain("AKM curator")
+      expect(promptArgs.body.parts[0].text).toContain("release workflow")
+    })
+
     it("akm_search passes source filter", async () => {
       const hooks = await AkmPlugin(createPluginInput())
       await hooks.tool!.akm_search.execute(
@@ -675,6 +740,179 @@ describe("akm-opencode plugin", () => {
           }),
         },
       })
+    })
+
+    it("injects akm hints into the system prompt after session.created fires", async () => {
+      mockExecFileSync.mockImplementation((cmd, args) => {
+        if (args[0] === "--version") return "0.1.0"
+        if (Array.isArray(args) && args.includes("hints")) return "Use `akm curate` first.\n"
+        return "mock output"
+      })
+
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.event!({
+        event: { type: "session.created", properties: { sessionID: "session-hints-1" } },
+      } as any)
+
+      const output = { system: [] as string[] }
+      await hooks["experimental.chat.system.transform"]!(
+        { sessionID: "session-hints-1" } as any,
+        output as any,
+      )
+
+      expect(output.system).toHaveLength(1)
+      expect(output.system[0]).toContain("AKM is available in this session")
+      expect(output.system[0]).toContain("Use `akm curate` first.")
+
+      // Hints should only inject once per session.
+      const second = { system: [] as string[] }
+      await hooks["experimental.chat.system.transform"]!(
+        { sessionID: "session-hints-1" } as any,
+        second as any,
+      )
+      expect(second.system).toHaveLength(0)
+    })
+
+    it("curates on chat.message and injects the result once into system transform", async () => {
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        if (Array.isArray(args) && args.includes("curate")) {
+          return "# skills\n- skill:deploy — ship the app\n"
+        }
+        return "mock output"
+      })
+
+      const client = createMockClient()
+      const hooks = await AkmPlugin(createPluginInput({ client: client as any }))
+
+      await hooks["chat.message"]!(
+        { sessionID: "session-curate-1", messageID: "m1", agent: "build" } as any,
+        { message: {} as any, parts: [{ type: "text", text: "Help me deploy the application to production" }] as any },
+      )
+
+      const curateCall = (mockExecFileSync.mock.calls as any[]).find(
+        ([, args]) => Array.isArray(args) && args.includes("curate"),
+      )
+      expect(curateCall).toBeDefined()
+
+      const output = { system: [] as string[] }
+      await hooks["experimental.chat.system.transform"]!(
+        { sessionID: "session-curate-1" } as any,
+        output as any,
+      )
+      expect(output.system).toHaveLength(1)
+      expect(output.system[0]).toContain("AKM stash — assets relevant to this prompt")
+      expect(output.system[0]).toContain("skill:deploy")
+
+      // Curated context is one-shot per turn.
+      const second = { system: [] as string[] }
+      await hooks["experimental.chat.system.transform"]!(
+        { sessionID: "session-curate-1" } as any,
+        second as any,
+      )
+      expect(second.system).toHaveLength(0)
+    })
+
+    it("skips curate when the user prompt is shorter than AKM_CURATE_MIN_CHARS", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks["chat.message"]!(
+        { sessionID: "session-short-1", messageID: "m1", agent: "build" } as any,
+        { message: {} as any, parts: [{ type: "text", text: "hi" }] as any },
+      )
+      const curateCall = (mockExecFileSync.mock.calls as any[]).find(
+        ([, args]) => Array.isArray(args) && args.includes("curate"),
+      )
+      expect(curateCall).toBeUndefined()
+    })
+
+    it("records auto positive feedback after a successful akm tool invocation", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockClear()
+
+      await hooks["tool.execute.after"]!(
+        {
+          tool: "akm_show",
+          sessionID: "session-feedback-1",
+          callID: "call-1",
+          args: { ref: "skill:deploy" },
+        } as any,
+        {
+          title: "show skill",
+          output: JSON.stringify({ type: "skill", ref: "skill:deploy" }),
+          metadata: {},
+        } as any,
+      )
+
+      const feedbackCall = (mockExecFileSync.mock.calls as any[]).find(
+        ([, args]) => Array.isArray(args) && args.includes("feedback"),
+      )
+      expect(feedbackCall).toBeDefined()
+      expect(feedbackCall[1]).toContain("skill:deploy")
+      expect(feedbackCall[1]).toContain("--positive")
+    })
+
+    it("does not auto-feedback for memory refs and never recurses into akm_feedback", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockClear()
+
+      await hooks["tool.execute.after"]!(
+        {
+          tool: "akm_feedback",
+          sessionID: "session-feedback-2",
+          callID: "call-1",
+          args: { ref: "skill:deploy" },
+        } as any,
+        {
+          title: "feedback",
+          output: JSON.stringify({ ok: true, type: "feedback" }),
+          metadata: {},
+        } as any,
+      )
+
+      await hooks["tool.execute.after"]!(
+        {
+          tool: "akm_show",
+          sessionID: "session-feedback-2",
+          callID: "call-2",
+          args: { ref: "memory:release-retro" },
+        } as any,
+        {
+          title: "show memory",
+          output: JSON.stringify({ type: "memory", ref: "memory:release-retro" }),
+          metadata: {},
+        } as any,
+      )
+
+      const feedbackCall = (mockExecFileSync.mock.calls as any[]).find(
+        ([, args]) => Array.isArray(args) && args.includes("feedback"),
+      )
+      expect(feedbackCall).toBeUndefined()
+    })
+
+    it("captures a session memory on stop when the buffer has enough entries", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+
+      // Seed the session buffer with two tool refs.
+      await hooks["tool.execute.after"]!(
+        { tool: "akm_show", sessionID: "session-capture-1", callID: "c1", args: { ref: "skill:alpha" } } as any,
+        { title: "show", output: JSON.stringify({ type: "skill", ref: "skill:alpha" }), metadata: {} } as any,
+      )
+      await hooks["tool.execute.after"]!(
+        { tool: "akm_show", sessionID: "session-capture-1", callID: "c2", args: { ref: "skill:beta" } } as any,
+        { title: "show", output: JSON.stringify({ type: "skill", ref: "skill:beta" }), metadata: {} } as any,
+      )
+
+      mockExecFileSync.mockClear()
+      await hooks.stop!({ sessionID: "session-capture-1" } as any)
+
+      const rememberCall = (mockExecFileSync.mock.calls as any[]).find(
+        ([, args]) => Array.isArray(args) && args.includes("remember"),
+      )
+      expect(rememberCall).toBeDefined()
+      const rememberArgs = rememberCall![1] as string[]
+      const nameFlag = rememberArgs.indexOf("--name")
+      expect(nameFlag).toBeGreaterThan(-1)
+      expect(rememberArgs[nameFlag + 1]).toMatch(/^opencode-session-/)
+      expect(rememberArgs).toContain("--force")
     })
 
     it("akm_agent creates child session and prompts with stash metadata", async () => {


### PR DESCRIPTION
## Summary

This PR implements a compound-engineering loop for the AKM OpenCode plugin that automatically improves the stash over time by curating relevant assets into each turn, recording feedback when assets are used, and capturing session memories when sessions end.

## Key Changes

- **Auto-curation on every turn**: Added `chat.message` hook that runs `akm curate` on user prompts (respecting `AKM_CURATE_MIN_CHARS` threshold) and injects the top matches into the system prompt via `experimental.chat.system.transform`.

- **Session hints at startup**: Added `session.created` event hook that warms the stash index in the background and caches `akm hints` output for injection into the first system transform, so the agent knows the CLI surface area immediately.

- **Auto-feedback on tool outcomes**: Extended `tool.execute.after` hook to automatically record `akm feedback <ref> --positive` or `--negative` based on whether akm tools succeeded or failed. Skips `memory:` refs and never recurses into `akm_feedback` itself.

- **Session memory capture**: Added `stop` event hook and lifecycle handlers for `session.idle`, `session.compacted`, and `session.deleted` that flush the session buffer (accumulated tool refs and memory intents) into a durable `memory:opencode-session-*` asset when sessions end.

- **New tools**:
  - `akm_curate`: Explicit tool to curate the stash for a task/topic with configurable limit and detail level.
  - `akm_evolve`: Dispatches the curator agent (with a system prompt defining the compound-engineering review process) into a child session to propose stash improvements.

- **Configuration via environment variables**:
  - `AKM_AUTO_FEEDBACK` (default: "1") — enable/disable auto-feedback
  - `AKM_AUTO_MEMORY` (default: "1") — enable/disable session memory capture
  - `AKM_AUTO_CURATE` (default: "1") — enable/disable auto-curation
  - `AKM_AUTO_HINTS` (default: "1") — enable/disable hints injection
  - `AKM_CURATE_LIMIT` (default: 5) — max curated matches per turn
  - `AKM_CURATE_MIN_CHARS` (default: 16) — minimum prompt length to curate
  - `AKM_CURATE_TIMEOUT_MS` (default: 8000) — timeout for curate/hints CLI calls

## Implementation Details

- **Per-session state**: Maps track hints, curated context, session buffers, and memory-captured flags keyed by OpenCode `sessionID` to isolate state across concurrent sessions.

- **Synchronous CLI invocation**: New `runCliSyncRaw()` helper uses `execFileSync` with timeouts for lifecycle hooks that cannot await async operations.

- **Asset ref extraction**: `extractToolRefs()` parses tool args and output (including nested `hits` and `assetHits` arrays) to find all asset references using the `AKM_REF_PATTERN` regex.

- **Session ID extraction**: `extractSessionIdFromEvent()` searches multiple payload paths (sessionID, session_id, nested properties, info) to reliably extract session IDs from OpenCode events.

- **Curator agent prompt**: Defines a detailed system prompt for the curator agent that inspects logs, session memories, and the live stash to identify hot/cold assets, coverage gaps, duplicates, and stale memories.

- **Comprehensive test coverage**: Added tests for hints injection, curation on chat messages, auto-feedback recording, session memory capture, and the new `akm_curate` and `akm_evolve` tools.

- **Documentation**: Updated README to describe the compound-engineering hooks, environment variables, and the new tools.

https://claude.ai/code/session_013BTjDjUuDR5yYq6PrKkWWi