### PR TITLE
feat: integrate akm v0.5.0 vaults, wikis, and workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
     {
       "name": "akm",
       "source": "./claude",
-      "description": "Search, show, and manage akm stash assets from local directories and registries via the akm CLI.",
-      "version": "0.4.3"
+      "description": "Search, show, curate, and manage akm stash assets — skills, commands, agents, knowledge, memories, scripts, workflows, vaults, and wikis — from local directories and registries via the akm CLI.",
+      "version": "0.5.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 ## Extended Searching
 
 You have access to a searchable library of tools, skills, commands, agents,
-and knowledge documents via `akm` CLI.
+knowledge, workflows, vaults, and wikis via the `akm` CLI (v0.5.0+).
 
 **Finding assets:**
 ```sh
 akm search "<query>"              # Search by keyword
-akm search "<query>" --type script  # Filter by type (script, skill, command, agent, knowledge)
-akm search "<query>" --source <source>  # Filter by source (e.g., "local", "registry", "both")
+akm search "<query>" --type script  # Filter by type (script, skill, command, agent, knowledge, memory, workflow, vault, wiki)
+akm search "<query>" --source <source>  # Filter by source (e.g., "stash", "registry", "both"; "local" is a legacy alias for "stash")
 ```
 Each hit includes a `ref` you use to retrieve the full asset.
 
@@ -21,9 +21,20 @@ What you get back depends on the asset type:
 - **skill** — Instructions to follow (read the full content)
 - **command** — A prompt template with placeholders to fill in
 - **agent** — A system prompt with model and tool hints
-- **knowledge** — A reference doc (use `toc` or `section "..."` as positional args to navigate, e.g. `akm show knowledge:guide toc`)
+- **knowledge** — A reference doc (use `toc` or `section "..."` as positional args, e.g. `akm show knowledge:guide toc`)
+- **wiki** — A page inside a wiki (`wiki:<name>/<page>`) with frontmatter, xrefs, and cited raw sources
+- **workflow** — A stateful multi-step procedure driven by `akm workflow start|next|complete|resume`
+- **vault** — A `.env`-style secret store. **Only key names surface** — values never appear in JSON, logs, or search indexes. Use `eval "$(akm vault load vault:<name>)"` to load into a shell.
 
 Always search the stash first when you need a capability. Prefer existing
 assets over writing new code.
+
+**New in v0.5.0:**
+- `akm wiki create|register|list|show|pages|search|stash|lint|ingest|remove` — manage multi-wiki knowledge bases
+- `akm vault create|list|show|set|unset|load` — manage secret stores (values never echoed)
+- `akm workflow start|next|complete|status|list|create|resume|template` — drive stateful runs
+- `akm save [-m "msg"]` — commit (and push, when writable) a git-backed stash
+- `akm import <file|-> [--name <slug>]` — promote a file into the indexed stash
+- `akm help migrate <version>` — release notes / migration guidance
 
 Use `akm -h` for more options and details on searching and using assets.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AKM Plugins
 
-Platform-specific plugins for the [AKM](https://github.com/itlackey/akm) CLI. Both packages wrap the `akm` CLI to **search**, **show**, **dispatch agents**, and **execute commands** from a stash directory.
+Platform-specific plugins for the [AKM](https://github.com/itlackey/akm) CLI (v0.5.0+). Both packages wrap the `akm` CLI to **search**, **show**, **dispatch agents**, **execute commands**, **drive workflows**, **manage wikis**, and **access vaults** from a stash directory.
 
 ## OpenCode
 
@@ -14,14 +14,14 @@ Add to your OpenCode config (`opencode.json`):
 }
 ```
 
-Provides seventeen tools:
-- `akm_search` — search the stash, the registry, or both
+Provides twenty-four tools:
+- `akm_search` — search the stash, the registry, or both (now including `workflow`, `vault`, and `wiki` types)
 - `akm_registry_search` — search configured registries for installable kits and optional asset hits
 - `akm_show` — show a stash asset by ref
 - `akm_index` — build/rebuild the search index
 - `akm_agent` — dispatch stash `agent:*` resources into OpenCode sessions
 - `akm_cmd` — execute stash `command:*` templates through OpenCode SDK sessions
-- `akm_add` — install kits from npm, GitHub, git URLs, or local directories
+- `akm_add` — install kits or register external sources (including wikis via `type: "wiki"`)
 - `akm_list` — list configured AKM sources
 - `akm_remove` — remove a configured AKM source
 - `akm_update` — update one or all managed AKM sources
@@ -32,6 +32,13 @@ Provides seventeen tools:
 - `akm_run` — execute a stash script via the `run` field
 - `akm_sources` — backward-compatible alias that lists configured AKM sources
 - `akm_upgrade` — check for or install akm CLI updates
+- `akm_curate` — curate stash assets for a task or topic
+- `akm_evolve` — dispatch the AKM curator agent
+- `akm_save` — commit (and push, when writable) a git-backed stash
+- `akm_import` — import a file (or stdin content) as a typed asset
+- `akm_vault` — manage vaults (`list`, `show`, `create`, `set`, `unset`, `shell_snippet`). Values never surface in any output channel
+- `akm_wiki` — manage wikis (`create`, `register`, `list`, `show`, `pages`, `search`, `stash`, `lint`, `ingest`, `remove`)
+- `akm_workflow` — drive workflow runs (`start`, `next`, `complete`, `status`, `list`, `create`, `template`, `resume`)
 
 The OpenCode plugin also hooks `chat.message` and `tool.execute.after` to record user/system feedback events and memory usage in OpenCode app logs when relevant.
 
@@ -83,7 +90,11 @@ stash/
 ├── skills/     # skill directories containing SKILL.md
 ├── commands/   # markdown files
 ├── agents/     # markdown files
-└── knowledge/  # markdown files
+├── knowledge/  # markdown files
+├── memories/   # markdown memory files (akm remember)
+├── workflows/  # multi-step procedures (workflow:<name>)
+├── vaults/     # .env secret stores (vault:<name>) — values never surface through structured output
+└── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
 ```
 
 Assets are resolved from three source types: **working** (local stash), **search paths** (additional dirs via `searchPaths` config), and **installed** (registry kits via `akm add`).

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "akm",
-  "description": "Search, show, and manage akm stash assets from local directories and registries, with agentic hooks that auto-load relevant assets, record memories, and feed asset-usage feedback back into the stash so it improves with every session.",
-  "version": "0.4.3",
+  "description": "Search, show, curate, and manage akm stash assets (skills, commands, agents, knowledge, memories, scripts, workflows, vaults, wikis) from local directories and registries, with agentic hooks that auto-load relevant assets, record memories, and feed asset-usage feedback back into the stash so it improves with every session.",
+  "version": "0.5.0",
   "author": {
     "name": "itlackey",
     "url": "https://github.com/itlackey"

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,6 +1,6 @@
 # akm-claude
 
-Claude Code plugin for the [AKM](https://github.com/itlackey/akm) CLI. Provides a skill that teaches Claude to **search**, **show**, **discover registry kits**, **dispatch agents**, and **execute commands** from stash directories and registries — plus **agentic hooks** that auto-load relevant assets, record memories, and feed asset-usage feedback back into the stash so it improves with every session.
+Claude Code plugin for the [AKM](https://github.com/itlackey/akm) CLI (v0.5.0+). Provides a skill that teaches Claude to **search**, **show**, **discover registry kits**, **dispatch agents**, **execute commands**, **drive workflows**, **manage wikis**, and **handle vaults safely** — plus **agentic hooks** that auto-load relevant assets, record memories, and feed asset-usage feedback back into the stash so it improves with every session.
 
 ## Installation
 
@@ -102,7 +102,11 @@ stash/
 ├── skills/     # skill directories containing SKILL.md
 ├── commands/   # markdown files
 ├── agents/     # markdown files
-└── knowledge/  # markdown files
+├── knowledge/  # markdown files
+├── memories/   # markdown memory files (akm remember)
+├── workflows/  # multi-step procedures (workflow:<name>)
+├── vaults/     # .env secret stores (vault:<name>) — values never surface through structured output
+└── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
 ```
 
 Assets are resolved from three source types: **working** (local stash), **search paths** (additional dirs via `searchPaths` config), and **installed** (registry kits via `akm add`).
@@ -138,7 +142,12 @@ or the CLI call fails, the hook exits silently without affecting the session.
 - `/akm-curate <task>` — manually curate stash assets for a topic and load them.
 - `/akm-remember [slug]` — distill the current conversation into a durable memory.
 - `/akm-feedback <ref> <+|-> [note]` — record explicit feedback on an asset.
-- `/akm-evolve [focus]` — dispatch the `akm-curator` agent to review session logs and propose stash improvements (promote hot assets, flag cold ones, draft missing coverage).
+- `/akm-evolve [focus]` — dispatch the `akm-curator` agent to review session logs and propose stash improvements.
+- `/akm-wiki <subcommand> [args]` — manage AKM wikis (create, register, list, show, pages, search, stash, lint, ingest, remove).
+- `/akm-workflow <subcommand> [args]` — drive workflow runs (start, next, complete, status, list, create, resume, template).
+- `/akm-save [name] [-m "msg"]` — commit (and push, when writable) a git-backed stash.
+
+Vault management is intentionally not exposed as a slash command — use `akm vault …` in the shell directly so secret values never pass through the chat turn.
 
 ## Docs
 

--- a/claude/agents/akm-curator.md
+++ b/claude/agents/akm-curator.md
@@ -19,9 +19,12 @@ You are the **AKM curator** — a compound-engineering agent whose job is to kee
 
 - **Hot refs** — assets that appear repeatedly in `memory.log` with `success` status. Run `akm feedback <ref> --positive --note "curator: consistently useful"` to boost their ranking.
 - **Cold refs** — assets that show up in `failure` entries or that users complain about in `feedback.log`. Record `akm feedback <ref> --negative --note "<excerpt>"` and open the asset for review.
-- **Missing coverage** — recurring prompt themes (from `feedback.log`) with no matching asset. Draft a new skill, command, or knowledge document in the working stash and register it with `akm index`.
+- **Missing coverage** — recurring prompt themes (from `feedback.log`) with no matching asset. Draft a new skill, command, knowledge doc, wiki page, or workflow in the working stash and register it with `akm index`.
 - **Duplicates / drift** — near-identical descriptions, overlapping responsibilities. Propose a consolidation.
-- **Stale memories** — session summaries older than N days that never get recalled. Propose `akm remove memory:<name>` once distilled into a durable knowledge doc.
+- **Stale memories** — session summaries older than N days that never get recalled. Propose `akm remove memory:<name>` once distilled into a durable knowledge doc or wiki page.
+- **Wiki hygiene** — run `akm wiki list` and `akm wiki lint <name>` on each wiki. Report orphans, broken xrefs, uncited raws, and stale indexes as fix candidates.
+- **Stuck workflows** — run `akm workflow list --active` and surface any runs in `blocked` or `failed` state with their step ids. Propose whether to `resume` or escalate.
+- **Never touch vaults** — do not call `akm vault show`, `akm vault load`, or otherwise enumerate vault keys unless the user explicitly requests it. Vault values must never appear in reports.
 
 ## Rules of engagement
 
@@ -47,6 +50,12 @@ End every run with a markdown report that has these sections:
 
 ## Duplicates / drift
 - <ref a> vs <ref b> — consolidation proposal
+
+## Wiki health
+- <wiki> — lint findings (orphan, broken-xref, uncited-raw, stale-index) with suggested fix
+
+## Workflow health
+- <workflow|runId> — blocked/failed state — resume or escalate
 
 ## Housekeeping
 - stale memories, reindex needs, config tweaks

--- a/claude/commands/akm-save.md
+++ b/claude/commands/akm-save.md
@@ -1,0 +1,14 @@
+---
+description: Commit (and push, when writable) pending changes in a git-backed AKM stash.
+argument-hint: [stash-name] [commit message]
+---
+
+Parse `"$ARGUMENTS"` into an optional stash name and an optional commit message. Run:
+
+```sh
+akm --format json -q save [<stash-name>] [-m "<message>"]
+```
+
+Only commits when the target stash is a git-backed source. Pushes automatically when the stash is marked `writable` in config and has a remote configured. No-op for non-git stashes.
+
+Report the resulting commit sha (or the "no changes" status) back to the user. If the user asked you to save after editing stash assets and no changes were committed, suggest running `akm index` and confirming the stash is git-initialized and writable (`akm config get writable`).

--- a/claude/commands/akm-wiki.md
+++ b/claude/commands/akm-wiki.md
@@ -1,0 +1,23 @@
+---
+description: Manage AKM wikis — scaffold, register external sources, stash raw content, lint, or search a wiki.
+argument-hint: <create|register|list|show|pages|search|stash|lint|ingest|remove> [args]
+---
+
+Parse `"$ARGUMENTS"` as a subcommand followed by its arguments and route to `akm wiki`.
+
+Recognized subcommands (see the AKM skill for the full contract):
+
+- `create <name>` — scaffold `<stashDir>/wikis/<name>/` with `schema.md`, `index.md`, `log.md`, and `raw/`.
+- `register <name> <ref> [--writable] [--trust] [--max-pages N] [--max-depth N]` — register an existing directory, git repo, or website as a first-class wiki.
+- `list` — summaries with page/raw counts and last-modified timestamps.
+- `show <name>` — path, description, counts, last 3 log entries.
+- `pages <name>` — author-written pages only (excludes schema/index/log/raw).
+- `search <name> <query> [--limit N]` — scoped search inside a single wiki.
+- `stash <name> <source> [--as <slug>]` — copy a file (or `-` for stdin) into `wikis/<name>/raw/<slug>.md` with frontmatter.
+- `lint <name>` — run structural lint (orphans, broken xrefs, missing descriptions, uncited raws, stale index). Exits 1 when findings exist; still emits a JSON report.
+- `ingest <name>` — print the ingest workflow for this wiki (does not run the ingest — drive it yourself).
+- `remove <name> --force [--with-sources]` — remove a wiki. Preserves `raw/` unless `--with-sources` is passed.
+
+Run `akm --format json -q wiki <subcommand> <args>` and report the parsed result back to the user. When running `lint`, report findings grouped by kind (orphan, broken-xref, missing-description, uncited-raw, stale-index, broken-source) and suggest next steps. When running `ingest`, hand the returned workflow steps to the user for confirmation before performing any ingest actions.
+
+If the user asks to "refresh" or "reindex" a wiki, run `akm wiki lint <name>` first to surface any structural issues, then regenerate content as needed.

--- a/claude/commands/akm-workflow.md
+++ b/claude/commands/akm-workflow.md
@@ -1,0 +1,21 @@
+---
+description: Drive AKM workflow runs — start, step, complete, resume, inspect status.
+argument-hint: <start|next|complete|status|list|create|resume|template> [args]
+---
+
+Parse `"$ARGUMENTS"` as a subcommand followed by its arguments and route to `akm workflow`.
+
+Recognized subcommands:
+
+- `start <workflow-ref> [--params <json>]` — start a new run of `workflow:<name>`. Returns `{ runId, ... }`.
+- `next <target> [--params <json>]` — advance a run. `<target>` may be a `runId` or a workflow ref (passing a ref auto-starts a new run).
+- `complete <runId> --step <id> [--state completed|blocked|failed|skipped] [--notes "..."] [--evidence <json>]` — record a step transition. Default state is `completed`.
+- `status <target>` — show the current state of a run (`runId` or workflow ref for most recent run).
+- `list [--ref <workflow>] [--active]` — enumerate runs; `--active` restricts to non-terminal runs.
+- `create <name> [--from <file>] [--force] [--reset]` — author a new workflow asset. `--force` requires `--from` or `--reset`.
+- `resume <runId>` — flip a `blocked` or `failed` run back to active.
+- `template` — print the starter markdown template to stdout.
+
+Run `akm --format json -q workflow <subcommand> <args>` and report the result. For `start` and `next`, capture the returned `runId` and offer to run the next step. For `complete`, confirm with the user before transitioning to a non-default state (`blocked`, `failed`, `skipped`). For `list --active`, surface any stuck runs the user may want to resume.
+
+When the user says "run workflow X" without specifying a runId, prefer `akm workflow next workflow:<X>` — it auto-starts a fresh run and performs the first step in one call.

--- a/claude/hooks/akm-hook.sh
+++ b/claude/hooks/akm-hook.sh
@@ -247,8 +247,9 @@ output = get_text(data.get("output")) or get_text(data.get("tool_output")) or ge
 combined = "\n".join(part for part in (command, output) if part)
 
 # Detect any asset ref that akm might know about. Ref grammar from the skill:
-#   [origin//]type:name   where type ∈ {skill, command, agent, knowledge, memory, script}
-ref_pattern = re.compile(r"(?:[A-Za-z0-9@._+/-]+//)?(?:skill|command|agent|knowledge|memory|script):[A-Za-z0-9._/-]+")
+#   [origin//]type:name   where type ∈ {skill, command, agent, knowledge, memory,
+#                                       script, workflow, vault, wiki}
+ref_pattern = re.compile(r"(?:[A-Za-z0-9@._+/-]+//)?(?:skill|command|agent|knowledge|memory|script|workflow|vault|wiki):[A-Za-z0-9._/-]+")
 refs = set(ref_pattern.findall(combined))
 
 if not refs and "akm remember" in command:
@@ -357,6 +358,7 @@ auto_feedback() {
     [ -n "$ref" ] || continue
     case "$ref" in
       memory:*) continue ;;  # memories don't take feedback today
+      vault:*) continue ;;   # vault values never surface — feedback is noise
     esac
     akm_run --format json -q feedback "$ref" "$sentiment_flag" --note "$note" >/dev/null
   done

--- a/claude/package.json
+++ b/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-claude",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "private": true,
   "description": "Claude Code plugin for AKM skills and hooks.",
   "license": "MPL-2.0",

--- a/claude/skills/akm/SKILL.md
+++ b/claude/skills/akm/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: akm
-description: Search, show, dispatch agents, and execute commands from an AKM stash directory. Use when the user wants to find or use tools, skills, commands, agents, or knowledge in their stash.
+description: Search, show, dispatch agents, execute commands, run workflows, manage wikis and vaults, and curate stash assets via the akm CLI. Use when the user wants to find or use tools, skills, commands, agents, knowledge, wikis, vaults, or workflows.
 ---
 
 # AKM Stash
 
-You have access to the `akm` CLI (AKM) to manage extension assets from a stash directory.
+You have access to the `akm` CLI (AKM, v0.5.0+) to manage extension assets from a stash directory.
 
 ### Stash directory resolution
 
@@ -24,6 +24,9 @@ The stash directory contains:
 - **knowledge/** — markdown knowledge files
 - **memories/** — markdown memory files recorded with `akm remember`
 - **scripts/** — executable scripts (.sh, .ts, .js, .ps1, .cmd, .bat, .py, .rb, .go, .pl, .php, .lua, .r, .swift, .kt)
+- **workflows/** — multi-step procedures (`workflow:<name>`) driven by `akm workflow`
+- **vaults/** — `.env` files (`vault:<name>`) whose values are managed by `akm vault` and **never** surface in JSON, logs, or search indexes
+- **wikis/** — per-wiki directories (`<stashDir>/wikis/<name>/`) containing `schema.md`, `index.md`, `log.md`, `raw/`, and agent-authored pages referenced as `wiki:<name>/<page>`
 
 ### Multi-source resolution
 
@@ -59,7 +62,7 @@ Use `--full` to force a full reindex instead of incremental. Run this after addi
 Find assets using a hybrid search pipeline: semantic embeddings + TF-IDF ranking. Falls back to name substring matching when no index exists.
 
 ```bash
-akm search [query] [--type skill|command|agent|knowledge|memory|script|any] [--limit N] [--source stash|local|registry|both]
+akm search [query] [--type skill|command|agent|knowledge|memory|script|workflow|vault|wiki|any] [--limit N] [--source stash|local|registry|both]
 ```
 
 Square brackets denote optional arguments; pipe-separated values denote allowed choices for a single flag.
@@ -191,6 +194,76 @@ rather than only answering the user. Options:
 - Call the `akm-curator` agent (or run `/akm-evolve`) at the end of a long
   session to consolidate hot assets, flag cold ones, and draft missing
   coverage.
+
+## Wikis
+
+Wikis are first-class knowledge bases under `<stashDir>/wikis/<name>/`. Each wiki has `schema.md` (rulebook), `index.md` (regenerable catalog), `log.md` (append-only, agent-maintained), `raw/` (immutable ingested sources), and agent-authored pages referenced as `wiki:<name>/<page>`. Wiki names must match `[a-z0-9][a-z0-9-]*`.
+
+```bash
+akm wiki create <name>                                # scaffold a new wiki
+akm wiki register <name> <ref> [--writable] [--trust] [--max-pages N] [--max-depth N]
+akm wiki list                                         # summaries with counts + last-modified
+akm wiki show <name>                                  # path, description, last 3 log entries
+akm wiki pages <name>                                 # author-written pages only (excludes schema/index/log/raw)
+akm wiki search <name> <query> [--limit N]            # scoped wiki search
+akm wiki stash <name> <source> [--as <slug>]          # copy a file/stdin into wikis/<name>/raw/
+akm wiki lint <name>                                  # orphan/xref/description/uncited-raw/stale-index checks
+akm wiki ingest <name>                                # print the ingest workflow for the agent to drive
+akm wiki remove <name> --force [--with-sources]       # preserves raw/ by default
+```
+
+`register` accepts directory paths, git URLs (`github:owner/repo`, `git+https://…`), and website roots (`https://…`). `--writable` marks a git-backed source as push-writable for `akm save`. `--trust` bypasses the install-audit block for this one registration.
+
+Page frontmatter fields: `description`, `pageKind`, `xrefs: wiki:<name>/<page>[]` (bidirectional — lint enforces), `sources: raw/<slug>[]`. `wikiRole` is reserved for `index`/`raw`.
+
+`akm wiki lint` exits 1 when findings exist — still returns a JSON report.
+
+## Vaults
+
+Vaults are `.env`-style key/value stores under `<stashDir>/vaults/<name>.env`, referenced as `vault:<name>` (or `vault:team/prod` for nested). **Values never surface in any structured channel** — not in the search index, not in `.stash.json`, not in `akm show`, not in any JSON output. Only the `vault load` command emits a shell snippet intended for `eval`.
+
+```bash
+akm vault create <name>                               # scaffold vaults/<name>.env (mode 0600)
+akm vault list [<ref>]                                # list vaults, or list keys + comments of one vault
+akm vault show <ref>                                  # key names + comments only (no values)
+akm vault set <ref> <key> [value] [--comment "..."]   # key may also be KEY=VALUE
+akm vault unset <ref> <key>
+akm vault load <ref>                                  # emits shell text: use with eval "$(akm vault load vault:<n>)"
+```
+
+**Hard rules when handling vaults:**
+- Never read or echo vault values. If the user needs to load them, run `eval "$(akm vault load vault:<name>)"` in their shell — do not pipe the output through the LLM.
+- Never write vault values back to chat, logs, or files. If a user shares a value to be stored, call `akm vault set …` directly and confirm by key name only.
+- Vault refs do not accept `akm feedback` (the hooks skip them automatically).
+
+## Workflows
+
+Workflows are stateful multi-step procedures. A workflow is an asset (`workflow:<name>`) that describes ordered steps; a **run** is a live instance driven forward with `akm workflow next` / `complete`.
+
+```bash
+akm workflow template                                 # print the starter markdown to stdout
+akm workflow create <name> [--from <file>] [--force] [--reset]
+akm workflow start <ref> [--params <json>]            # → { runId, ... }
+akm workflow next <target> [--params <json>]          # target = runId OR workflow ref (auto-starts)
+akm workflow complete <runId> --step <id> [--state completed|blocked|failed|skipped] [--notes "..."] [--evidence <json>]
+akm workflow status <target>                          # runId OR workflow ref (resolves most recent run)
+akm workflow list [--ref <workflow>] [--active]
+akm workflow resume <runId>                           # flip blocked/failed → active
+```
+
+When the user asks you to run a workflow, prefer `akm workflow next <ref>` for the first call (auto-starts a new run) and then track the returned `runId` for subsequent `complete`/`next` calls.
+
+## Saving and importing
+
+```bash
+akm save [name] [-m "message"]                        # commit (and push, if writable) a git-backed stash
+akm import <source> [--name <slug>] [--force]         # promote a file (or stdin with "-") into the indexed stash
+akm help migrate <version>                            # release notes / migration guidance (e.g. 0.5.0)
+akm enable <skills.sh|context-hub>                    # toggle optional components
+akm disable <skills.sh|context-hub>
+```
+
+Use `akm save` at the end of a session to persist stash edits when the primary stash is git-backed and marked `writable`. Use `akm import` to register a drafted markdown file as a first-class asset.
 
 ## Dispatching Stash Agents
 

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,6 +1,6 @@
 # akm-opencode
 
-OpenCode plugin for the [AKM](https://github.com/itlackey/akm) CLI. Registers tools that let your AI agent **search**, **show**, and **manage** extension assets from stash directories and registries — plus **agentic hooks** that auto-load relevant assets into each turn, record feedback when assets are used, and harvest session memories so the stash improves with every session.
+OpenCode plugin for the [AKM](https://github.com/itlackey/akm) CLI (v0.5.0+). Registers tools that let your AI agent **search**, **show**, and **manage** stash assets — skills, commands, agents, knowledge, memories, scripts, workflows, vaults, and wikis — plus **agentic hooks** that auto-load relevant assets into each turn, record feedback when assets are used, and harvest session memories so the stash improves with every session.
 
 ## Installation
 
@@ -16,25 +16,30 @@ Add to your OpenCode config (`opencode.json`):
 
 | Tool | Description |
 |------|-------------|
-| `akm_search` | Search the local stash, the registry, or both for scripts, skills, commands, agents, and knowledge |
+| `akm_search` | Search the local stash, the registry, or both. Type filter accepts `skill`, `command`, `agent`, `knowledge`, `memory`, `script`, `workflow`, `vault`, `wiki`, `any` |
 | `akm_registry_search` | Search configured registries for installable kits and optional asset-level hits |
 | `akm_show` | Show a stash asset by its ref |
 | `akm_index` | Build or rebuild the search index |
 | `akm_agent` | Dispatch a stash `agent:*` into OpenCode using the stash prompt and metadata |
 | `akm_cmd` | Execute a stash `command:*` template in OpenCode via SDK session prompting |
-| `akm_add` | Install kits from npm, GitHub, git URLs, or local directories |
+| `akm_add` | Install kits or register external sources from npm, GitHub, git URLs, URLs, or local dirs (use `type: "wiki"` to register a wiki; `writable`, `trust`, `max_pages`, `max_depth`, `provider`, `options` also supported) |
 | `akm_list` | List configured AKM sources |
 | `akm_remove` | Remove a configured AKM source and reindex |
 | `akm_update` | Update one managed source or all managed sources |
 | `akm_clone` | Clone an asset into the working stash or a custom destination for editing |
 | `akm_remember` | Record a memory in the default stash |
-| `akm_feedback` | Record positive or negative feedback for a stash asset |
+| `akm_feedback` | Record positive or negative feedback for a stash asset (skipped automatically for `memory:` and `vault:` refs) |
 | `akm_config` | Get, set, unset, list, or inspect akm configuration (including `config path --all`) |
 | `akm_run` | Execute a stash script using its `run` field |
 | `akm_sources` | Backward-compatible alias that lists configured AKM sources |
 | `akm_upgrade` | Check for or install akm CLI updates |
 | `akm_curate` | Curate the stash for a task or topic and return ranked matches the agent can use |
 | `akm_evolve` | Dispatch the AKM curator agent to review recent session activity and propose stash improvements |
+| `akm_save` | Commit (and push, when writable) pending changes in a git-backed stash |
+| `akm_import` | Import a file (or stdin content) into the stash as a typed asset |
+| `akm_vault` | Manage vaults (`list`, `show`, `create`, `set`, `unset`, `shell_snippet`). **Values never surface** — `show`/`list` return key names only. `shell_snippet` returns opaque `eval` text |
+| `akm_wiki` | Manage wikis (`create`, `register`, `list`, `show`, `pages`, `search`, `stash`, `lint`, `ingest`, `remove`) |
+| `akm_workflow` | Drive workflow runs (`start`, `next`, `complete`, `status`, `list`, `create`, `template`, `resume`) |
 
 ## Compound-engineering hooks
 
@@ -142,8 +147,28 @@ stash/
 ├── skills/     # skill directories containing SKILL.md
 ├── commands/   # markdown files
 ├── agents/     # markdown files
-└── knowledge/  # markdown files
+├── knowledge/  # markdown files
+├── memories/   # markdown memory files (akm remember)
+├── workflows/  # multi-step procedures (workflow:<name>)
+├── vaults/     # .env secret stores (vault:<name>) — values never surface through structured output
+└── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
 ```
+
+## Vaults
+
+`akm_vault` is the one tool in this plugin with a hard contract on output. The
+AKM CLI itself guarantees vault values never appear in JSON, the search index,
+`.stash.json`, or any structured output channel. This plugin mirrors that:
+
+- `action: "list"` / `"show"` return key names and comments only.
+- `action: "set"` / `"unset"` never echo the value.
+- `action: "shell_snippet"` wraps `akm vault load` and returns the raw shell
+  text as-is. Treat it as opaque and hand it straight to a shell via
+  `eval "$(…)"` — do not log it, do not pass it through another tool, and do
+  not let the agent inspect it.
+
+Automatic feedback recording (`tool.execute.after`) skips `vault:*` refs so
+that usage signals can't leak which vault was touched.
 
 Assets are resolved from three source types: **working** (local stash), **search paths** (additional dirs via `searchPaths` config), and **installed** (registry kits via `akm add`).
 

--- a/opencode/index.ts
+++ b/opencode/index.ts
@@ -29,7 +29,7 @@ const sessionBuffer = new Map<string, SessionBufferEntry[]>()
 const sessionMemoryCaptured = new Set<string>()
 
 // Asset-ref grammar matching the stash skill: [origin//]type:name
-const AKM_REF_PATTERN = /(?:[A-Za-z0-9@._+/-]+\/\/)?(?:skill|command|agent|knowledge|memory|script):[A-Za-z0-9._/\-]+/g
+const AKM_REF_PATTERN = /(?:[A-Za-z0-9@._+/-]+\/\/)?(?:skill|command|agent|knowledge|memory|script|workflow|vault|wiki):[A-Za-z0-9._/\-]+/g
 
 const CURATOR_AGENT_PROMPT = `You are the AKM curator — a compound-engineering agent that keeps the user's AKM stash improving every time the main agent finishes a task.
 
@@ -41,9 +41,12 @@ Inputs you should inspect:
 Signals to act on:
 - Hot refs: assets repeatedly appearing in positive tool outcomes. Call akm_feedback <ref> positive --note "curator: consistently useful" to reinforce.
 - Cold refs: assets tied to failures or user complaints. Record akm_feedback <ref> negative --note "<excerpt>" and open the asset for review.
-- Missing coverage: recurring user prompts with no matching asset. Draft a new skill, command, or knowledge doc in the working stash and reindex with akm_index.
+- Missing coverage: recurring user prompts with no matching asset. Draft a new skill, command, knowledge doc, wiki page, or workflow in the working stash and reindex with akm_index.
 - Duplicates / drift: near-identical descriptions or overlapping responsibilities. Propose a consolidation.
-- Stale memories: session summaries that never get recalled. Propose akm_remove memory:<name> once distilled into a durable knowledge doc.
+- Stale memories: session summaries that never get recalled. Propose akm_remove memory:<name> once distilled into a durable knowledge doc or wiki page.
+- Wiki hygiene: for each wiki returned by akm_wiki list, run akm_wiki lint <name> and report orphans, broken xrefs, uncited raws, and stale indexes as fix candidates.
+- Stuck workflows: run akm_workflow list --active and surface any runs in blocked or failed state with their step ids. Propose whether to resume or escalate.
+- Never touch vaults: do not call akm_vault show or shell_snippet unless the user explicitly asks. Vault values must never appear in reports.
 
 Rules of engagement:
 - Never apply destructive changes without explicit user approval.
@@ -65,6 +68,12 @@ Output shape: end every run with a markdown report that has these sections:
 
 ## Duplicates / drift
 - <ref a> vs <ref b> — consolidation proposal
+
+## Wiki health
+- <wiki> — lint findings (orphan, broken-xref, uncited-raw, stale-index) with suggested fix
+
+## Workflow health
+- <workflow|runId> — blocked/failed state — resume or escalate
 
 ## Housekeeping
 - stale memories, reindex needs, config tweaks
@@ -488,7 +497,29 @@ async function runCli(client: LogCapableClient, args: string[], meta: CliLogMeta
 }
 
 type CliError = { ok: false; error: string }
-type AssetType = "agent" | "command" | "knowledge" | "memory" | "script" | "skill"
+type AssetType =
+  | "agent"
+  | "command"
+  | "knowledge"
+  | "memory"
+  | "script"
+  | "skill"
+  | "workflow"
+  | "vault"
+  | "wiki"
+
+const ASSET_TYPES = [
+  "agent",
+  "command",
+  "knowledge",
+  "memory",
+  "script",
+  "skill",
+  "workflow",
+  "vault",
+  "wiki",
+  "any",
+] as const
 
 type ShowAgentResponse = {
   type: "agent"
@@ -868,7 +899,7 @@ function normalizeSearchSource(source: "local" | "stash" | "registry" | "both"):
 
 function createSearchArgs(input: {
   query: string
-  type?: AssetType | "any"
+  type?: AssetType | "any" | string
   limit?: number
   source?: "local" | "stash" | "registry" | "both"
   defaultSource?: "local" | "stash" | "registry" | "both"
@@ -1073,8 +1104,10 @@ export const AkmPlugin: Plugin = async ({ client }) => {
           ? `opencode auto: ${input.tool} succeeded`
           : `opencode auto: ${input.tool} failed`
         for (const ref of allRefs) {
-          // Memories do not accept feedback in the current CLI.
-          if (ref.startsWith("memory:")) continue
+          // Memories and vault refs are not first-class feedback targets —
+          // memories do not accept feedback, and vault values never surface in
+          // JSON so automatic usage signals would be misleading.
+          if (ref.startsWith("memory:") || ref.startsWith("vault:")) continue
           const ok = recordFeedbackSync(ref, feedback, note)
           if (!ok) break
         }
@@ -1082,11 +1115,11 @@ export const AkmPlugin: Plugin = async ({ client }) => {
     },
     tool: {
     akm_search: tool({
-      description: "Search your stash or the akm registry for scripts, skills, commands, agents, knowledge, and memories. Use source='registry' or akm_registry_search for installable community kits.",
+      description: "Search your stash or the akm registry for scripts, skills, commands, agents, knowledge, memories, workflows, vaults, and wikis. Use source='registry' or akm_registry_search for installable community kits.",
       args: {
         query: tool.schema.string().describe("Case-insensitive substring search."),
         type: tool.schema
-          .enum(["agent", "command", "knowledge", "memory", "script", "skill", "any"])
+          .enum(ASSET_TYPES as unknown as [string, ...string[]])
           .optional()
           .describe("Optional type filter. Defaults to 'any'."),
         limit: tool.schema.number().optional().describe("Maximum number of hits to return. Defaults to 20."),
@@ -1104,7 +1137,7 @@ export const AkmPlugin: Plugin = async ({ client }) => {
       args: {
         query: tool.schema.string().describe("Search query for installable registry kits."),
         type: tool.schema
-          .enum(["agent", "command", "knowledge", "memory", "script", "skill", "any"])
+          .enum(ASSET_TYPES as unknown as [string, ...string[]])
           .optional()
           .describe("Optional asset type filter. Defaults to 'any'."),
         limit: tool.schema.number().optional().describe("Maximum number of registry hits to return. Defaults to 20."),
@@ -1170,12 +1203,29 @@ export const AkmPlugin: Plugin = async ({ client }) => {
       },
     }),
     akm_add: tool({
-      description: "Install a kit from npm, GitHub, another git host, or a local directory. Installed kits become searchable alongside local assets.",
+      description: "Install a kit or register an external source from npm, GitHub, another git host, a URL, or a local directory. Use type='wiki' to register a wiki source instead of a stash kit.",
       args: {
-        package_ref: tool.schema.string().describe("Package reference such as npm:@scope/kit, github:<owner>/<repo>, git+https://host/repo, or ./local/kit."),
+        package_ref: tool.schema.string().describe("Package reference such as npm:@scope/kit, github:<owner>/<repo>, git+https://host/repo, https://url, or ./local/kit."),
+        type: tool.schema.enum(["wiki"]).optional().describe("Route the add through a typed registrar. 'wiki' registers an external wiki source."),
+        name: tool.schema.string().optional().describe("Optional name to register the source under."),
+        writable: tool.schema.boolean().optional().describe("Mark a git-backed source as push-writable (used by akm save)."),
+        trust: tool.schema.boolean().optional().describe("Bypass install-audit blocking for this registration only."),
+        provider: tool.schema.string().optional().describe("Provider hint (required for raw URL refs, e.g. 'github', 'website')."),
+        options: tool.schema.string().optional().describe("JSON string of provider-specific options."),
+        max_pages: tool.schema.number().optional().describe("Cap for website crawlers (default 50)."),
+        max_depth: tool.schema.number().optional().describe("Depth cap for website crawlers (default 3)."),
       },
-      async execute({ package_ref }) {
-        return runCli(client as unknown as LogCapableClient, ["add", package_ref], { toolName: "akm_add" })
+      async execute({ package_ref, type, name, writable, trust, provider, options, max_pages, max_depth }) {
+        const args = ["add", package_ref]
+        if (type) args.push("--type", type)
+        if (name) args.push("--name", name)
+        if (writable) args.push("--writable")
+        if (trust) args.push("--trust")
+        if (provider) args.push("--provider", provider)
+        if (options) args.push("--options", options)
+        if (max_pages != null) args.push("--max-pages", String(max_pages))
+        if (max_depth != null) args.push("--max-depth", String(max_depth))
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_add" })
       },
     }),
     akm_list: tool({
@@ -1565,6 +1615,324 @@ export const AkmPlugin: Plugin = async ({ client }) => {
       args: {},
       async execute() {
         return runCli(client as unknown as LogCapableClient, ["list"], { toolName: "akm_sources" })
+      },
+    }),
+    akm_save: tool({
+      description: "Commit (and push, when writable) pending changes in a git-backed stash. No-op for non-git stashes.",
+      args: {
+        name: tool.schema.string().optional().describe("Optional stash source name. Defaults to the primary stash."),
+        message: tool.schema.string().optional().describe("Commit message. Defaults to an auto-generated summary."),
+      },
+      async execute({ name, message }) {
+        const args = ["save"]
+        if (name) args.push(name)
+        if (message) args.push("-m", message)
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_save" })
+      },
+    }),
+    akm_import: tool({
+      description: "Import a file (or stdin) into the stash as a typed asset. Pass '-' as source to read from a string via content.",
+      args: {
+        source: tool.schema.string().describe("Path to the source file, or '-' to read from stdin (use 'content' to provide it)."),
+        name: tool.schema.string().optional().describe("Optional asset name override."),
+        force: tool.schema.boolean().optional().describe("Overwrite an existing asset with the same name."),
+        content: tool.schema.string().optional().describe("Raw content to feed on stdin when source is '-'."),
+      },
+      async execute({ source, name, force, content }) {
+        const args = ["import", source]
+        if (name) args.push("--name", name)
+        if (force) args.push("--force")
+        const command = resolveAkmCommand()
+        if (typeof command !== "string") return JSON.stringify(command)
+        if (source === "-" && content) {
+          try {
+            const stdout = execFileSync(command, [...args, "--format", "json"], {
+              encoding: "utf8",
+              timeout: 60_000,
+              input: content,
+            })
+            return stdout
+          } catch (error: unknown) {
+            return JSON.stringify({ ok: false, error: formatCliError(error) })
+          }
+        }
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_import" })
+      },
+    }),
+    akm_vault: tool({
+      description: "Manage encrypted-at-rest vaults of KEY=VALUE pairs. Values never surface in any output channel — 'show'/'list' return key names only, 'set'/'unset' never echo the value. Use 'shell_snippet' to get a shell-eval snippet that loads values into the process.",
+      args: {
+        action: tool.schema.enum(["list", "show", "create", "set", "unset", "shell_snippet"]).describe("Vault subcommand. 'shell_snippet' wraps 'vault load' — treat its output as opaque shell text meant for eval."),
+        ref: tool.schema.string().optional().describe("Vault ref such as vault:prod or vault:team/prod. Required for show/set/unset/shell_snippet; optional for list."),
+        name: tool.schema.string().optional().describe("Vault name when action is 'create' (e.g. 'prod' → vaults/prod.env)."),
+        key: tool.schema.string().optional().describe("Variable name for set/unset. May include '=' to pass KEY=VALUE in one field when value is omitted."),
+        value: tool.schema.string().optional().describe("Value to store. Never echoed back."),
+        comment: tool.schema.string().optional().describe("Optional inline '# comment' written above the key for 'set'."),
+      },
+      async execute({ action, ref, name, key, value, comment }) {
+        const logMeta = { toolName: "akm_vault" }
+        switch (action) {
+          case "list": {
+            const args = ["vault", "list"]
+            if (ref) args.push(ref)
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "show": {
+            if (!ref) return JSON.stringify({ ok: false, error: "'ref' is required for action='show'." })
+            return runCli(client as unknown as LogCapableClient, ["vault", "show", ref], logMeta)
+          }
+          case "create": {
+            if (!name) return JSON.stringify({ ok: false, error: "'name' is required for action='create'." })
+            return runCli(client as unknown as LogCapableClient, ["vault", "create", name], logMeta)
+          }
+          case "set": {
+            if (!ref) return JSON.stringify({ ok: false, error: "'ref' is required for action='set'." })
+            if (!key) return JSON.stringify({ ok: false, error: "'key' is required for action='set'." })
+            const args = ["vault", "set", ref, key]
+            if (value != null) args.push(value)
+            if (comment) args.push("--comment", comment)
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "unset": {
+            if (!ref) return JSON.stringify({ ok: false, error: "'ref' is required for action='unset'." })
+            if (!key) return JSON.stringify({ ok: false, error: "'key' is required for action='unset'." })
+            return runCli(client as unknown as LogCapableClient, ["vault", "unset", ref, key], logMeta)
+          }
+          case "shell_snippet": {
+            if (!ref) return JSON.stringify({ ok: false, error: "'ref' is required for action='shell_snippet'." })
+            // `vault load` emits raw shell — not JSON. Return the snippet verbatim
+            // so the caller can hand it to a shell via eval. Never parse values.
+            const command = resolveAkmCommand()
+            if (typeof command !== "string") return JSON.stringify(command)
+            try {
+              const stdout = execFileSync(command, ["vault", "load", ref], {
+                encoding: "utf8",
+                timeout: 30_000,
+              })
+              return JSON.stringify({ ok: true, ref, shell: stdout.trim() })
+            } catch (error: unknown) {
+              return JSON.stringify({ ok: false, error: formatCliError(error) })
+            }
+          }
+        }
+      },
+    }),
+    akm_wiki: tool({
+      description: "Manage AKM wikis — multi-wiki knowledge bases under <stashDir>/wikis/<name>/. Supports scaffolding, registering external sources, listing pages, scoped search, stashing raw sources, lint, and ingest workflow.",
+      args: {
+        action: tool.schema.enum([
+          "create",
+          "register",
+          "list",
+          "show",
+          "remove",
+          "pages",
+          "search",
+          "stash",
+          "lint",
+          "ingest",
+        ]).describe("Wiki subcommand."),
+        name: tool.schema.string().optional().describe("Wiki name (required for every action except 'list')."),
+        source_ref: tool.schema.string().optional().describe("Source ref to register (required for action='register'). Accepts directory paths, git URLs, github owner/repo, or https:// website roots."),
+        writable: tool.schema.boolean().optional().describe("When registering a git-backed source, mark it as push-writable (used by akm_save)."),
+        trust: tool.schema.boolean().optional().describe("Bypass install-audit blocking for this registration only."),
+        max_pages: tool.schema.number().optional().describe("Crawler page cap when registering a website (default 50)."),
+        max_depth: tool.schema.number().optional().describe("Crawler depth cap when registering a website (default 3)."),
+        query: tool.schema.string().optional().describe("Query string for action='search'."),
+        limit: tool.schema.number().optional().describe("Result cap for action='search'."),
+        source: tool.schema.string().optional().describe("Source path (or '-' for stdin) for action='stash'."),
+        as_slug: tool.schema.string().optional().describe("Explicit slug for action='stash' (defaults to derived from source)."),
+        content: tool.schema.string().optional().describe("Raw content to feed stdin when stashing with source='-'."),
+        force: tool.schema.boolean().optional().describe("Required for action='remove'."),
+        with_sources: tool.schema.boolean().optional().describe("When removing, also delete the raw/ sources (default false)."),
+      },
+      async execute({ action, name, source_ref, writable, trust, max_pages, max_depth, query, limit, source, as_slug, content, force, with_sources }) {
+        const logMeta = { toolName: "akm_wiki" }
+        const requireName = () => {
+          if (!name) return JSON.stringify({ ok: false, error: `'name' is required for action='${action}'.` })
+          return null
+        }
+        switch (action) {
+          case "list":
+            return runCli(client as unknown as LogCapableClient, ["wiki", "list"], logMeta)
+          case "create": {
+            const err = requireName(); if (err) return err
+            return runCli(client as unknown as LogCapableClient, ["wiki", "create", name!], logMeta)
+          }
+          case "show": {
+            const err = requireName(); if (err) return err
+            return runCli(client as unknown as LogCapableClient, ["wiki", "show", name!], logMeta)
+          }
+          case "pages": {
+            const err = requireName(); if (err) return err
+            return runCli(client as unknown as LogCapableClient, ["wiki", "pages", name!], logMeta)
+          }
+          case "ingest": {
+            const err = requireName(); if (err) return err
+            return runCli(client as unknown as LogCapableClient, ["wiki", "ingest", name!], logMeta)
+          }
+          case "lint": {
+            const err = requireName(); if (err) return err
+            // `wiki lint` exits 1 when findings exist, which runCli surfaces as
+            // an error envelope. That is still useful output — the JSON body is
+            // the lint report. Pass through either way.
+            return runCli(client as unknown as LogCapableClient, ["wiki", "lint", name!], logMeta)
+          }
+          case "register": {
+            const err = requireName(); if (err) return err
+            if (!source_ref) return JSON.stringify({ ok: false, error: "'source_ref' is required for action='register'." })
+            const args = ["wiki", "register", name!, source_ref]
+            if (writable) args.push("--writable")
+            if (trust) args.push("--trust")
+            if (max_pages != null) args.push("--max-pages", String(max_pages))
+            if (max_depth != null) args.push("--max-depth", String(max_depth))
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "remove": {
+            const err = requireName(); if (err) return err
+            if (!force) return JSON.stringify({ ok: false, error: "'force' must be true to remove a wiki." })
+            const args = ["wiki", "remove", name!, "--force"]
+            if (with_sources) args.push("--with-sources")
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "search": {
+            const err = requireName(); if (err) return err
+            if (!query) return JSON.stringify({ ok: false, error: "'query' is required for action='search'." })
+            const args = ["wiki", "search", name!, query]
+            if (limit != null) args.push("--limit", String(limit))
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "stash": {
+            const err = requireName(); if (err) return err
+            if (!source) return JSON.stringify({ ok: false, error: "'source' is required for action='stash'." })
+            const args = ["wiki", "stash", name!, source]
+            if (as_slug) args.push("--as", as_slug)
+            if (source === "-" && content) {
+              const command = resolveAkmCommand()
+              if (typeof command !== "string") return JSON.stringify(command)
+              try {
+                const stdout = execFileSync(command, [...args, "--format", "json"], {
+                  encoding: "utf8",
+                  timeout: 60_000,
+                  input: content,
+                })
+                return stdout
+              } catch (error: unknown) {
+                return JSON.stringify({ ok: false, error: formatCliError(error) })
+              }
+            }
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+        }
+      },
+    }),
+    akm_workflow: tool({
+      description: "Manage AKM workflow runs — stateful multi-step procedures defined as workflow:<name> assets. Use start/next/complete/resume to drive a run, status/list to inspect, create/template to author.",
+      args: {
+        action: tool.schema.enum([
+          "start",
+          "next",
+          "complete",
+          "status",
+          "list",
+          "create",
+          "template",
+          "resume",
+        ]).describe("Workflow subcommand."),
+        ref: tool.schema.string().optional().describe("Workflow ref (e.g. workflow:release). Required for start; accepted by next/status as a target."),
+        target: tool.schema.string().optional().describe("Run id or workflow ref for next/status. When a workflow ref is passed to 'next', a new run is auto-started."),
+        run_id: tool.schema.string().optional().describe("Workflow run id. Required for complete and resume."),
+        params: tool.schema.string().optional().describe("JSON object string of parameters for start/next."),
+        step: tool.schema.string().optional().describe("Step id to transition (required for action='complete')."),
+        state: tool.schema.enum(["completed", "blocked", "failed", "skipped"]).optional().describe("Step state for 'complete'. Defaults to 'completed'."),
+        notes: tool.schema.string().optional().describe("Freeform notes attached to the step transition."),
+        evidence: tool.schema.string().optional().describe("JSON object string of evidence attached to the step transition."),
+        name: tool.schema.string().optional().describe("Workflow name for action='create'."),
+        from: tool.schema.string().optional().describe("Path to a markdown template for action='create'."),
+        force: tool.schema.boolean().optional().describe("Overwrite an existing workflow on create (requires --from or --reset)."),
+        reset: tool.schema.boolean().optional().describe("Reset to the built-in template for action='create'."),
+        filter_ref: tool.schema.string().optional().describe("Restrict action='list' to runs of this workflow ref."),
+        active_only: tool.schema.boolean().optional().describe("Restrict action='list' to active (non-terminal) runs."),
+      },
+      async execute({
+        action,
+        ref,
+        target,
+        run_id,
+        params,
+        step,
+        state,
+        notes,
+        evidence,
+        name,
+        from,
+        force,
+        reset,
+        filter_ref,
+        active_only,
+      }) {
+        const logMeta = { toolName: "akm_workflow" }
+        switch (action) {
+          case "start": {
+            if (!ref) return JSON.stringify({ ok: false, error: "'ref' is required for action='start'." })
+            const args = ["workflow", "start", ref]
+            if (params) args.push("--params", params)
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "next": {
+            const picked = target ?? run_id ?? ref
+            if (!picked) return JSON.stringify({ ok: false, error: "'target', 'run_id', or 'ref' is required for action='next'." })
+            const args = ["workflow", "next", picked]
+            if (params) args.push("--params", params)
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "complete": {
+            if (!run_id) return JSON.stringify({ ok: false, error: "'run_id' is required for action='complete'." })
+            if (!step) return JSON.stringify({ ok: false, error: "'step' is required for action='complete'." })
+            const args = ["workflow", "complete", run_id, "--step", step]
+            if (state) args.push("--state", state)
+            if (notes) args.push("--notes", notes)
+            if (evidence) args.push("--evidence", evidence)
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "status": {
+            const picked = target ?? run_id ?? ref
+            if (!picked) return JSON.stringify({ ok: false, error: "'target', 'run_id', or 'ref' is required for action='status'." })
+            return runCli(client as unknown as LogCapableClient, ["workflow", "status", picked], logMeta)
+          }
+          case "list": {
+            const args = ["workflow", "list"]
+            if (filter_ref) args.push("--ref", filter_ref)
+            if (active_only) args.push("--active")
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "create": {
+            if (!name) return JSON.stringify({ ok: false, error: "'name' is required for action='create'." })
+            const args = ["workflow", "create", name]
+            if (from) args.push("--from", from)
+            if (force) args.push("--force")
+            if (reset) args.push("--reset")
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "template": {
+            // The workflow template is emitted as raw markdown, not JSON.
+            const command = resolveAkmCommand()
+            if (typeof command !== "string") return JSON.stringify(command)
+            try {
+              const stdout = execFileSync(command, ["workflow", "template"], {
+                encoding: "utf8",
+                timeout: 30_000,
+              })
+              return JSON.stringify({ ok: true, template: stdout })
+            } catch (error: unknown) {
+              return JSON.stringify({ ok: false, error: formatCliError(error) })
+            }
+          }
+          case "resume": {
+            if (!run_id) return JSON.stringify({ ok: false, error: "'run_id' is required for action='resume'." })
+            return runCli(client as unknown as LogCapableClient, ["workflow", "resume", run_id], logMeta)
+          }
+        }
       },
     }),
     akm_upgrade: tool({

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "akm-opencode",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "type": "module",
-  "description": "OpenCode plugin for AKM - search, show, and manage extension assets via the akm CLI, with agentic hooks that auto-load relevant stash assets, record feedback, and harvest session memories so the stash improves every session.",
+  "description": "OpenCode plugin for AKM - search, show, and manage extension assets via the akm CLI, including v0.5.0 vaults, wikis, and workflows, with agentic hooks that auto-load relevant stash assets, record feedback, and harvest session memories so the stash improves every session.",
   "keywords": [
     "opencode",
     "opencode-ai",

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -90,8 +90,13 @@ describe("akm-opencode plugin", () => {
       expect(toolNames).toContain("akm_upgrade")
       expect(toolNames).toContain("akm_curate")
       expect(toolNames).toContain("akm_evolve")
+      expect(toolNames).toContain("akm_save")
+      expect(toolNames).toContain("akm_import")
+      expect(toolNames).toContain("akm_vault")
+      expect(toolNames).toContain("akm_wiki")
+      expect(toolNames).toContain("akm_workflow")
       expect(toolNames).not.toContain("akm_submit")
-      expect(toolNames).toHaveLength(19)
+      expect(toolNames).toHaveLength(24)
     })
 
     it("returns lifecycle hooks for the compound-engineering loop", async () => {
@@ -234,6 +239,83 @@ describe("akm-opencode plugin", () => {
       const upgrade = hooks.tool!.akm_upgrade
       expect(upgrade.args.check).toBeDefined()
       expect(upgrade.args.force).toBeDefined()
+    })
+
+    it("akm_save has required args schema", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const save = hooks.tool!.akm_save
+      expect(save.args.name).toBeDefined()
+      expect(save.args.message).toBeDefined()
+    })
+
+    it("akm_import has required args schema", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const imp = hooks.tool!.akm_import
+      expect(imp.args.source).toBeDefined()
+      expect(imp.args.name).toBeDefined()
+      expect(imp.args.force).toBeDefined()
+      expect(imp.args.content).toBeDefined()
+    })
+
+    it("akm_vault has required args schema", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const vault = hooks.tool!.akm_vault
+      expect(vault.args.action).toBeDefined()
+      expect(vault.args.ref).toBeDefined()
+      expect(vault.args.name).toBeDefined()
+      expect(vault.args.key).toBeDefined()
+      expect(vault.args.value).toBeDefined()
+      expect(vault.args.comment).toBeDefined()
+    })
+
+    it("akm_wiki has required args schema", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const wiki = hooks.tool!.akm_wiki
+      expect(wiki.args.action).toBeDefined()
+      expect(wiki.args.name).toBeDefined()
+      expect(wiki.args.source_ref).toBeDefined()
+      expect(wiki.args.writable).toBeDefined()
+      expect(wiki.args.trust).toBeDefined()
+      expect(wiki.args.max_pages).toBeDefined()
+      expect(wiki.args.max_depth).toBeDefined()
+      expect(wiki.args.query).toBeDefined()
+      expect(wiki.args.source).toBeDefined()
+      expect(wiki.args.as_slug).toBeDefined()
+      expect(wiki.args.force).toBeDefined()
+      expect(wiki.args.with_sources).toBeDefined()
+    })
+
+    it("akm_workflow has required args schema", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const wf = hooks.tool!.akm_workflow
+      expect(wf.args.action).toBeDefined()
+      expect(wf.args.ref).toBeDefined()
+      expect(wf.args.target).toBeDefined()
+      expect(wf.args.run_id).toBeDefined()
+      expect(wf.args.params).toBeDefined()
+      expect(wf.args.step).toBeDefined()
+      expect(wf.args.state).toBeDefined()
+      expect(wf.args.evidence).toBeDefined()
+      expect(wf.args.name).toBeDefined()
+      expect(wf.args.from).toBeDefined()
+      expect(wf.args.force).toBeDefined()
+      expect(wf.args.reset).toBeDefined()
+      expect(wf.args.filter_ref).toBeDefined()
+      expect(wf.args.active_only).toBeDefined()
+    })
+
+    it("akm_add exposes the expanded v0.5.0 flag surface", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const add = hooks.tool!.akm_add
+      expect(add.args.package_ref).toBeDefined()
+      expect(add.args.type).toBeDefined()
+      expect(add.args.name).toBeDefined()
+      expect(add.args.writable).toBeDefined()
+      expect(add.args.trust).toBeDefined()
+      expect(add.args.provider).toBeDefined()
+      expect(add.args.options).toBeDefined()
+      expect(add.args.max_pages).toBeDefined()
+      expect(add.args.max_depth).toBeDefined()
     })
   })
 
@@ -1974,6 +2056,293 @@ describe("akm-opencode plugin", () => {
         ["upgrade", "--force", "--format", "json"],
         expect.objectContaining({ encoding: "utf8" }),
       )
+    })
+  })
+
+  describe("v0.5.0 tool execution", () => {
+    it("akm_save invokes the CLI with name and message", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_save.execute({ name: "stash", message: "checkpoint" } as any, {} as any)
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["save", "stash", "-m", "checkpoint", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_import pipes content on stdin when source is '-'", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_import.execute(
+        { source: "-", content: "# snippet", name: "notes" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["import", "-", "--name", "notes", "--format", "json"],
+        expect.objectContaining({ input: "# snippet" }),
+      )
+    })
+
+    it("akm_vault set forwards ref, key, value, and comment", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_vault.execute(
+        { action: "set", ref: "vault:prod", key: "API_KEY", value: "s3kret", comment: "prod key" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["vault", "set", "vault:prod", "API_KEY", "s3kret", "--comment", "prod key", "--format", "json"],
+        expect.any(Object),
+      )
+    })
+
+    it("akm_vault shell_snippet returns raw shell text wrapped in JSON", async () => {
+      // `resolveAkmCommand` probes the binary via --version before the actual
+      // command runs, so route shell output only for the vault-load invocation.
+      mockExecFileSync.mockImplementation((_cmd, args) => {
+        if (Array.isArray(args) && args[0] === "vault" && args[1] === "load") {
+          return ". '/tmp/vault.sh'; rm -f '/tmp/vault.sh'"
+        }
+        return "mock output"
+      })
+      const hooks = await AkmPlugin(createPluginInput())
+      const result = await hooks.tool!.akm_vault.execute(
+        { action: "shell_snippet", ref: "vault:prod" } as any,
+        {} as any,
+      )
+      const parsed = JSON.parse(result as string)
+      expect(parsed.ok).toBe(true)
+      expect(parsed.ref).toBe("vault:prod")
+      expect(parsed.shell).toContain(". '/tmp/vault.sh'")
+    })
+
+    it("akm_vault rejects set without a key", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const result = await hooks.tool!.akm_vault.execute(
+        { action: "set", ref: "vault:prod" } as any,
+        {} as any,
+      )
+      expect(JSON.parse(result as string)).toEqual({ ok: false, error: "'key' is required for action='set'." })
+    })
+
+    it("akm_wiki register passes writable, trust, and crawler caps", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_wiki.execute(
+        {
+          action: "register",
+          name: "team",
+          source_ref: "https://example.com/docs",
+          writable: true,
+          trust: true,
+          max_pages: 120,
+          max_depth: 4,
+        } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        [
+          "wiki",
+          "register",
+          "team",
+          "https://example.com/docs",
+          "--writable",
+          "--trust",
+          "--max-pages",
+          "120",
+          "--max-depth",
+          "4",
+          "--format",
+          "json",
+        ],
+        expect.any(Object),
+      )
+    })
+
+    it("akm_wiki remove requires force and forwards --with-sources", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const denied = await hooks.tool!.akm_wiki.execute(
+        { action: "remove", name: "team" } as any,
+        {} as any,
+      )
+      expect(JSON.parse(denied as string)).toEqual({ ok: false, error: "'force' must be true to remove a wiki." })
+
+      await hooks.tool!.akm_wiki.execute(
+        { action: "remove", name: "team", force: true, with_sources: true } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["wiki", "remove", "team", "--force", "--with-sources", "--format", "json"],
+        expect.any(Object),
+      )
+    })
+
+    it("akm_wiki stash streams content on stdin when source is '-'", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_wiki.execute(
+        {
+          action: "stash",
+          name: "team",
+          source: "-",
+          as_slug: "intro",
+          content: "# intro",
+        } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["wiki", "stash", "team", "-", "--as", "intro", "--format", "json"],
+        expect.objectContaining({ input: "# intro" }),
+      )
+    })
+
+    it("akm_workflow start passes --params JSON verbatim", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_workflow.execute(
+        { action: "start", ref: "workflow:release", params: '{"tag":"v1"}' } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["workflow", "start", "workflow:release", "--params", '{"tag":"v1"}', "--format", "json"],
+        expect.any(Object),
+      )
+    })
+
+    it("akm_workflow complete requires run_id and step and forwards evidence", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const missing = await hooks.tool!.akm_workflow.execute(
+        { action: "complete", step: "qa" } as any,
+        {} as any,
+      )
+      expect(JSON.parse(missing as string).ok).toBe(false)
+
+      await hooks.tool!.akm_workflow.execute(
+        {
+          action: "complete",
+          run_id: "run-1",
+          step: "qa",
+          state: "blocked",
+          notes: "awaiting review",
+          evidence: '{"url":"https://ex.com/1"}',
+        } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        [
+          "workflow",
+          "complete",
+          "run-1",
+          "--step",
+          "qa",
+          "--state",
+          "blocked",
+          "--notes",
+          "awaiting review",
+          "--evidence",
+          '{"url":"https://ex.com/1"}',
+          "--format",
+          "json",
+        ],
+        expect.any(Object),
+      )
+    })
+
+    it("akm_workflow next accepts either a run id or a workflow ref", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_workflow.execute(
+        { action: "next", ref: "workflow:release" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["workflow", "next", "workflow:release", "--format", "json"],
+        expect.any(Object),
+      )
+    })
+
+    it("akm_add routes wiki registrations through --type wiki", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      await hooks.tool!.akm_add.execute(
+        {
+          package_ref: "https://example.com/docs",
+          type: "wiki",
+          name: "docs",
+          writable: true,
+          provider: "website",
+          max_pages: 80,
+        } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        [
+          "add",
+          "https://example.com/docs",
+          "--type",
+          "wiki",
+          "--name",
+          "docs",
+          "--writable",
+          "--provider",
+          "website",
+          "--max-pages",
+          "80",
+          "--format",
+          "json",
+        ],
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe("v0.5.0 ref pattern", () => {
+    it("extracts workflow, vault, and wiki refs from tool output", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const output = JSON.stringify({
+        ok: true,
+        hits: [
+          { ref: "workflow:release" },
+          { ref: "vault:prod" },
+          { ref: "wiki:team/intro" },
+          { ref: "skill:review" },
+        ],
+      })
+      const logCalls: any[] = []
+      const input = createPluginInput({
+        client: {
+          ...(createMockClient() as any),
+          app: {
+            log: mock(async (payload: any) => {
+              logCalls.push(payload)
+              return { data: {}, error: undefined }
+            }),
+          },
+        },
+      })
+      const hooks2 = await AkmPlugin(input)
+      await hooks2["tool.execute.after"]!(
+        { tool: "akm_search", args: {}, sessionID: "s1", callID: "c1" } as any,
+        { title: "t", output, metadata: {} } as any,
+      )
+      const memoryLog = logCalls.find((c) => c.body?.extra?.subsystem === "feedback")
+      expect(memoryLog).toBeDefined()
+      // Verify the ref extraction picked up the v0.5.0 asset types by checking
+      // that feedback was recorded for the non-memory, non-vault refs.
+      // Auto-feedback wraps its call as: [..., "-q", "feedback", <ref>, ...]
+      const feedbackRefs = mockExecFileSync.mock.calls
+        .filter((call: any[]) => Array.isArray(call[1]) && call[1].includes("feedback"))
+        .map((call: any[]) => {
+          const args = call[1] as string[]
+          return args[args.indexOf("feedback") + 1]
+        })
+      expect(feedbackRefs).toContain("workflow:release")
+      expect(feedbackRefs).toContain("wiki:team/intro")
+      expect(feedbackRefs).toContain("skill:review")
+      // Vault refs MUST NOT receive automatic feedback.
+      expect(feedbackRefs).not.toContain("vault:prod")
     })
   })
 


### PR DESCRIPTION
Adds plugin coverage for the v0.5.0 asset types (workflow, vault, wiki)
and the new CLI surface (save, import) across both the OpenCode and
Claude Code plugins so agents can discover and operate on the new stash
content without dropping to raw shell.

OpenCode plugin
- New tools: akm_save, akm_import, akm_vault, akm_wiki, akm_workflow
  (24 tools total, up from 19). Vault operations never surface values —
  show/list return keys only and shell_snippet treats the eval text as
  opaque. Wiki covers create/register/list/show/pages/search/stash/lint/
  ingest/remove. Workflow covers start/next/complete/status/list/create/
  template/resume.
- akm_add gains the v0.5.0 flag surface (type, name, writable, trust,
  provider, options, max_pages, max_depth) so wiki sources and
  audit-gated registrations flow through the existing tool.
- Asset type enums on search/registry_search now include workflow,
  vault, and wiki. Ref extraction in tool.execute.after follows. Auto-
  feedback skips vault:* refs alongside memory:* to avoid leaking
  usage signals about secret stores.

Claude Code plugin
- SKILL.md documents wikis, vaults, workflows, save, import, and
  help/enable/disable; declares the hard rule that vault values must
  never pass through the chat turn.
- New slash commands: /akm-wiki, /akm-workflow, /akm-save. No vault
  slash command by design.
- Hook ref pattern extended to workflow|vault|wiki; auto-feedback skips
  vault:* refs so secret-store usage never flows to akm feedback.
- Curator agent (both Claude-side markdown and the embedded OpenCode
  prompt) reports wiki lint health, stuck workflow runs, and explicitly
  refuses to inspect vaults.

Tests
- 131 tests pass (bun test tests/). New coverage: tool registration
  counts, schema shapes, execution wiring for save/import/vault/wiki/
  workflow/add, and ref-extraction behaviour that records feedback for
  workflow and wiki refs while skipping vault refs.

Versioning
- marketplace.json, claude plugin.json, claude/package.json, and
  opencode/package.json bumped to 0.5.0. Descriptions updated to
  mention the new asset types.