### PR TITLE
Add v0.7.0 proposal queue, lessons, and agent CLI integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "akm",
       "source": "./claude",
       "description": "Search, show, curate, and manage akm stash assets — skills, commands, agents, knowledge, memories, scripts, workflows, vaults, and wikis — from local directories and registries via the akm CLI.",
-      "version": "0.6.0"
+      "version": "0.7.0"
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,18 @@
 ## Extended Searching
 
 You have access to a searchable library of tools, skills, commands, agents,
-knowledge, workflows, vaults, and wikis via the `akm` CLI (v0.6.1+).
+knowledge, lessons, workflows, vaults, and wikis via the `akm` CLI (v0.7.0+).
 
 > For any AKM verb that isn't a first-class tool/slash-command, agents should call `akm_help` (OpenCode) or `/akm-help` (Claude Code) to discover the right `akm` CLI invocation before reaching for raw flags.
 
 **Finding assets:**
 ```sh
 akm search "<query>"              # Search by keyword
-akm search "<query>" --type script  # Filter by type (script, skill, command, agent, knowledge, memory, workflow, vault, wiki)
+akm search "<query>" --type script  # Filter by type (script, skill, command, agent, knowledge, memory, lesson, workflow, vault, wiki)
 akm search "<query>" --source <source>  # Filter by source (e.g., "stash", "registry", "both"; "local" is a legacy alias for "stash")
+akm search "<query>" --include-proposed  # Merge proposed-quality drafts into hits (default search hides them)
 ```
-Each hit includes a `ref` you use to retrieve the full asset.
+Each hit includes a `ref` you use to retrieve the full asset, plus optional `quality?` (`curated`/`generated`/`proposed`/unknown) and `warnings?` fields.
 
 **Using assets:**
 ```sh
@@ -24,12 +25,21 @@ What you get back depends on the asset type:
 - **command** — A prompt template with placeholders to fill in
 - **agent** — A system prompt with model and tool hints
 - **knowledge** — A reference doc (use `toc` or `section "..."` as positional args, e.g. `akm show knowledge:guide toc`)
+- **lesson** — A durable learning with required `description` and `when_to_use` frontmatter, normally produced by `akm distill <ref>` and accepted via `akm proposal accept`
 - **wiki** — A page inside a wiki (`wiki:<name>/<page>`) with frontmatter, xrefs, and cited raw sources
 - **workflow** — A stateful multi-step procedure driven by `akm workflow start|next|complete|resume`
 - **vault** — A `.env`-style secret store. **Only key names surface** — values never appear in JSON, logs, or search indexes. Use `eval "$(akm vault load vault:<name>)"` to load into a shell.
 
 Always search the stash first when you need a capability. Prefer existing
 assets over writing new code.
+
+**New in v0.7.0:**
+- `akm proposal list|show|diff|accept|reject` — operate the durable proposal queue. Always confirm with the user before `accept`/`reject`.
+- `akm reflect [ref] [--task "..."]` — generate a reflection proposal via the configured agent CLI.
+- `akm propose <type> <name> --task "..."` — generate a new-asset proposal via the configured agent CLI.
+- `akm distill <ref>` — distill repeated evidence into a `lesson` proposal (gated by `llm.features.feedback_distillation`).
+- `akm setup` — auto-detect installed agent CLIs and persist `agent.default`. Required once per machine for reflect/propose.
+- `akm search ... --include-proposed` — merge `quality:"proposed"` drafts into hits.
 
 **New in v0.5.0:**
 - `akm wiki create|register|list|show|pages|search|stash|lint|ingest|remove` — manage multi-wiki knowledge bases

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # AKM Plugins
 
-Platform-specific plugins for the [AKM](https://github.com/itlackey/akm) CLI (v0.6.1+). Both packages wrap the `akm` CLI to **search**, **show**, **dispatch agents**, **execute commands**, **drive workflows**, **manage wikis**, and **access vaults** from a stash directory.
+Platform-specific plugins for the [AKM](https://github.com/itlackey/akm) CLI (v0.7.0+). Both packages wrap the `akm` CLI to **search**, **show**, **dispatch agents**, **execute commands**, **drive workflows**, **manage wikis**, **access vaults**, **operate the v0.7.0 proposal queue**, and **distill lessons** from a stash directory.
+
+## What's new in 0.7.0
+
+The v0.7.0 release of akm finalizes the v1 architecture pre-release and introduces:
+
+- **Proposal queue** — `/akm-proposal` (Claude) / `akm_proposal` (OpenCode) operate `list / show / diff / accept / reject`. All proposal-producing commands write through one durable queue at `<stashRoot>/.akm/proposals/`; drafts never leak into search or commits.
+- **Reflect / propose / distill** — three new agent-CLI-backed proposal generators. `distill` runs the bounded in-tree LLM (gated by `llm.features.feedback_distillation`) to turn evidence into a `lesson` proposal.
+- **`lesson` asset type** — first-class type stored under `lessons/<name>.md` with required `description` and `when_to_use` frontmatter.
+- **`agent.*` config + `akm setup`** — auto-detects installed agent CLIs (`opencode`, `claude`, `codex`, `gemini`, `aider`) and persists `agent.default`. SessionStart runs this once per machine.
+- **`quality:"proposed"`** — excluded from default search; surface drafts via `--include-proposed` or `akm proposal *`. The plugin's auto-feedback hook automatically skips proposed-quality refs.
+
+See akm's [`docs/migration/release-notes/0.7.0.md`](https://github.com/itlackey/akm/blob/main/docs/migration/release-notes/0.7.0.md) for the full delta.
 
 ## OpenCode
 
@@ -14,8 +26,8 @@ Add to your OpenCode config (`opencode.json`):
 }
 ```
 
-Provides a trimmed surface of fourteen tools (down from twenty-six in 0.5.x — shipped in commit `9f9620f`). Verbs that are no longer first-class tools (`save`, `import`, `clone`, `update`, `remove`, `list`-sources, `registry-search`, `reindex`, `config`, `upgrade`, `run`, vault writes) are now discoverable through the new `akm_help` tool, which surfaces a curated quick-reference and falls back to live `akm --help` so agents can compose the right CLI invocation and run it via shell:
-- `akm_search` — search the stash, the registry, or both (including `workflow`, `vault`, and `wiki` types)
+Provides a surface of nineteen tools. Verbs that are not first-class tools (`save`, `import`, `clone`, `update`, `remove`, `list`-sources, `registry-search`, `reindex`, `config`, `upgrade`, `run`, raw `agent`, vault writes) are discoverable through the `akm_help` tool, which surfaces a curated quick-reference and falls back to live `akm --help` so agents can compose the right CLI invocation and run it via shell:
+- `akm_search` — search the stash, the registry, or both (including `workflow`, `vault`, `wiki`, and `lesson` types). Pass `--include-proposed` to merge proposed-quality drafts.
 - `akm_show` — show a stash asset by ref
 - `akm_agent` — dispatch stash `agent:*` resources into OpenCode sessions
 - `akm_workflow` — drive workflow runs (`start`, `next`, `complete`, `status`, `list`, `create`, `template`, `resume`)
@@ -26,6 +38,11 @@ Provides a trimmed surface of fourteen tools (down from twenty-six in 0.5.x — 
 - `akm_evolve` — dispatch the AKM curator subagent (review session activity, propose stash improvements, persist the report as a memory)
 - `akm_wiki` — manage wikis (`create`, `register`, `list`, `show`, `pages`, `search`, `stash`, `lint`, `ingest`, `remove`)
 - `akm_feedback` — record positive or negative feedback for a stash asset
+- `akm_proposal` — operate the v0.7.0 proposal queue (`list`, `show`, `diff`, `accept`, `reject`). Always confirm with the user before `accept`/`reject`.
+- `akm_reflect` — generate a reflection proposal via the configured agent CLI; output lands in the proposal queue.
+- `akm_propose` — generate a new-asset proposal via the configured agent CLI.
+- `akm_distill` — distill a ref into a proposed `lesson` (gated by `llm.features.feedback_distillation`).
+- `akm_setup` — detect installed agent CLIs and persist `agent.default`.
 - `akm_session_messages` — summarize a specific OpenCode session (restricted for arbitrary session IDs)
 - `akm_parent_messages` — summarize the parent OpenCode session for dispatched stash subagents
 - `akm_help` — quick-reference table for non-first-class `akm` verbs, with live `akm --help` fallback
@@ -66,11 +83,11 @@ claude plugin install akm@akm-plugins
 
 Provides:
 - **AKM Skill** — Claude automatically uses the akm CLI when you ask about stash assets
-- **Trimmed slash-command surface (12 verbs)** — `/akm-search`, `/akm-show`, `/akm-agent`, `/akm-cmd`, `/akm-curate`, `/akm-remember`, `/akm-feedback`, `/akm-evolve`, `/akm-wiki`, `/akm-workflow`, `/akm-vault` (`list`/`show`/`load`), and `/akm-help`
-- **`/akm-help` discovery flow** — for verbs no longer first-class (save, import, clone, update, remove, list-sources, registry-search, reindex, config, upgrade, run-script, vault writes), `/akm-help <task>` surfaces a curated quick-reference and falls back to live `akm --help` so Claude can compose the right `akm` invocation and run it via Bash
+- **Slash-command surface (18 verbs)** — `/akm-search`, `/akm-show`, `/akm-agent`, `/akm-cmd`, `/akm-curate`, `/akm-remember`, `/akm-feedback`, `/akm-evolve`, `/akm-wiki`, `/akm-workflow`, `/akm-vault` (`list`/`show`/`load`), `/akm-proposal` (`list`/`show`/`diff`/`accept`/`reject`), `/akm-review-proposals`, `/akm-reflect`, `/akm-propose`, `/akm-distill`, `/akm-setup`, and `/akm-help`
+- **`/akm-help` discovery flow** — for verbs without a dedicated slash command (save, import, clone, update, remove, list-sources, registry-search, reindex, config, upgrade, run-script, raw `agent`, vault writes), `/akm-help <task>` surfaces a curated quick-reference and falls back to live `akm --help` so Claude can compose the right `akm` invocation and run it via Bash
 - **Dynamic agent dispatch** — Claude fetches agent definitions from the stash and spawns subagents on the fly with the agent's prompt, tool constraints, and task
 - **Command execution** — Claude resolves command templates, renders argument placeholders (`$ARGUMENTS`, `$1`, `$2`), and executes the result
-- **Claude hooks** — the plugin refreshes `akm-cli@latest` on session start and records relevant user/system feedback and memory usage events in local state logs
+- **Claude hooks** — the plugin refreshes `akm-cli@latest` (override via `AKM_PACKAGE_REF`) on session start, runs `akm setup` once per machine to detect the agent CLI, surfaces pending-proposal counts in the SessionStart header, and records relevant user/system feedback and memory usage events in local state logs. Auto-feedback skips proposed-quality and `lesson:*` refs.
 
 ### All Other Agents
 
@@ -94,9 +111,11 @@ stash/
 ├── agents/     # markdown files
 ├── knowledge/  # markdown files
 ├── memories/   # markdown memory files (akm remember)
+├── lessons/    # first-class durable learnings (lesson:<name>) with description + when_to_use frontmatter
 ├── workflows/  # multi-step procedures (workflow:<name>)
 ├── vaults/     # .env secret stores (vault:<name>) — values never surface through structured output
-└── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
+├── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
+└── .akm/proposals/  # v0.7.0 proposal queue — drafts that never leak into search or commits
 ```
 
 Assets are resolved from three source types: **working** (local stash), **search paths** (additional dirs via `searchPaths` config), and **installed** (registry kits via `akm add`).

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "akm",
-  "description": "Search, show, curate, and manage akm stash assets (skills, commands, agents, knowledge, memories, scripts, workflows, vaults, wikis) from local directories and registries, with agentic hooks that auto-load relevant assets, record memories, and feed asset-usage feedback back into the stash so it improves with every session.",
-  "version": "0.6.0",
+  "description": "Search, show, curate, and manage akm stash assets (skills, commands, agents, knowledge, memories, lessons, scripts, workflows, vaults, wikis) from local directories and registries, with agentic hooks that auto-load relevant assets, record memories, route the akm v0.7.0 proposal queue, and feed asset-usage feedback back into the stash so it improves with every session.",
+  "version": "0.7.0",
   "author": {
     "name": "itlackey",
     "url": "https://github.com/itlackey"

--- a/claude/README.md
+++ b/claude/README.md
@@ -1,6 +1,6 @@
 # akm-claude
 
-Claude Code plugin for the [AKM](https://github.com/itlackey/akm) CLI (v0.6.1+). Provides a skill that teaches Claude to **search**, **show**, **discover registry kits**, **dispatch agents**, **execute commands**, **drive workflows**, **manage wikis**, and **handle vaults safely** — plus **agentic hooks** that auto-load relevant assets, record memories, and feed asset-usage feedback back into the stash so it improves with every session.
+Claude Code plugin for the [AKM](https://github.com/itlackey/akm) CLI (v0.7.0+). Provides a skill that teaches Claude to **search**, **show**, **discover registry kits**, **dispatch agents**, **execute commands**, **drive workflows**, **manage wikis**, **handle vaults safely**, **operate the v0.7.0 proposal queue**, and **distill lessons** — plus **agentic hooks** that auto-load relevant assets, record memories, surface pending proposals, run `akm setup` to detect the agent CLI, and feed asset-usage feedback back into the stash so it improves with every session.
 
 ## Installation
 
@@ -24,8 +24,8 @@ claude plugin install akm@akm-plugins
 ## What's included
 
 - **AKM Skill** — Claude automatically uses the `akm` CLI when you ask about stash assets
-- **Agentic hooks** — lifecycle hooks that install `akm`, auto-curate stash matches into every user prompt, auto-record feedback when assets are used, and harvest session memories at stop/compact time
-- **Slash commands** — a trimmed surface of 12 first-class verbs (`/akm-search`, `/akm-show`, `/akm-agent`, `/akm-cmd`, `/akm-curate`, `/akm-remember`, `/akm-feedback`, `/akm-evolve`, `/akm-wiki`, `/akm-workflow`, `/akm-vault`, `/akm-help`) for explicit control of the compound-engineering loop
+- **Agentic hooks** — lifecycle hooks that install `akm`, run `akm setup` once to detect the agent CLI, auto-curate stash matches into every user prompt, auto-record feedback when assets are used (skipping proposed-quality drafts and `lesson:*` refs), surface pending-proposal counts in the SessionStart header, and harvest session memories at stop/compact time
+- **Slash commands** — 18 first-class verbs (`/akm-search`, `/akm-show`, `/akm-agent`, `/akm-cmd`, `/akm-curate`, `/akm-remember`, `/akm-feedback`, `/akm-evolve`, `/akm-wiki`, `/akm-workflow`, `/akm-vault`, `/akm-proposal`, `/akm-review-proposals`, `/akm-reflect`, `/akm-propose`, `/akm-distill`, `/akm-setup`, `/akm-help`) for explicit control of the compound-engineering loop
 - **`akm-curator` agent** — a self-evolution subagent that reviews session logs and proposes stash improvements
 
 The skill teaches Claude to:
@@ -104,9 +104,11 @@ stash/
 ├── agents/     # markdown files
 ├── knowledge/  # markdown files
 ├── memories/   # markdown memory files (akm remember)
+├── lessons/    # first-class durable learnings (lesson:<name>) — produced by akm distill, accepted via akm proposal accept
 ├── workflows/  # multi-step procedures (workflow:<name>)
 ├── vaults/     # .env secret stores (vault:<name>) — values never surface through structured output
-└── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
+├── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
+└── .akm/proposals/  # v0.7.0 proposal queue — drafts that never leak into search or commits
 ```
 
 Assets are resolved from three source types: **working** (local stash), **search paths** (additional dirs via `searchPaths` config), and **installed** (registry kits via `akm add`).
@@ -119,9 +121,9 @@ or the CLI call fails, the hook exits silently without affecting the session.
 
 | Event | What happens |
 | --- | --- |
-| **SessionStart** | Installs/refreshes `akm-cli@latest` (Bun → npm fallback), warms the stash index in the background, injects `akm hints`, and runs a scoped `akm curate --run <session_id>` so Claude gets relevant stash context before the first user message. |
+| **SessionStart** | Installs/refreshes `akm-cli@latest` (override via `AKM_PACKAGE_REF`; Bun → npm fallback), runs `akm setup` once per machine to detect the configured agent CLI, surfaces it plus any pending-proposal count in the injected header, warms the stash index in the background, injects `akm hints`, and runs a scoped `akm curate --run <session_id>` so Claude gets relevant stash context before the first user message. |
 | **UserPromptSubmit** | Runs `akm curate "<prompt>" --run <session_id>` and injects the top matches as `additionalContext` so Claude sees relevant stash assets before answering. Short prompts (under `AKM_CURATE_MIN_CHARS` chars, default 16) are skipped. Also records `remember`/`memory` intents to the session buffer. |
-| **PostToolUse** (Bash, success) | Logs `akm` Bash invocations, harvests any `type:name` asset refs from command+output, and calls `akm feedback <ref> --positive` so successful usage boosts ranking. |
+| **PostToolUse** (Bash, success) | Logs `akm` Bash invocations, harvests any `type:name` asset refs (including `lesson:*`) from command+output, and calls `akm feedback <ref> --positive` so successful usage boosts ranking. Skips `memory:*`, `vault:*`, `lesson:*`, and any ref the indexer reports as `quality:"proposed"`. |
 | **PostToolUseFailure** (Bash) | Same as above but records `--negative` feedback with the failure note. |
 | **Stop** / **SubagentStop** | Flushes the per-session buffer into a `memory:claude-session-YYYYMMDD-<sid>` memory so every meaningful session contributes durable context for future searches. When `AKM_INDEX_ON_SESSION_END=1`, the hook follows that flush with `akm index` so upstream inference/graph passes run immediately. |
 | **PreCompact** | Same memory capture before Claude Code compacts the transcript, with the same optional post-flush `akm index` run when `AKM_INDEX_ON_SESSION_END=1`. |
@@ -130,18 +132,20 @@ or the CLI call fails, the hook exits silently without affecting the session.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
+| `AKM_PACKAGE_REF` | `akm-cli@latest` | Override the npm/bun package spec used by SessionStart auto-install (e.g. pin to `akm-cli@0.7.0` in CI). |
 | `AKM_AUTO_FEEDBACK` | `1` | Set to `0` to disable automatic `akm feedback` on tool success/failure. |
 | `AKM_AUTO_MEMORY` | `1` | Set to `0` to disable automatic session-summary memories. |
+| `AKM_AUTO_SETUP` | `1` | Set to `0` to disable the automatic `akm setup` run on first SessionStart. Set to `force` to re-run on every SessionStart. |
 | `AKM_INDEX_ON_SESSION_END` | `0` | Set to `1` to run `akm index` after a session-end memory is captured. |
 | `AKM_CURATE_LIMIT` | `5` | Max curated results injected into context per prompt. |
 | `AKM_CURATE_MIN_CHARS` | `16` | Minimum prompt length before curation runs. |
 | `AKM_CURATE_TIMEOUT` | `8` | Wall-clock seconds for `akm` invocations inside hooks. |
 | `AKM_CONTEXT_BUDGET_CHARS` | `4000` | Max total characters injected into `additionalContext` for a single hook fire. |
-| `AKM_PLUGIN_STATE_DIR` | `$XDG_STATE_HOME/akm-claude` | Where session logs and per-session buffers live. |
+| `AKM_PLUGIN_STATE_DIR` | `$XDG_STATE_HOME/akm-claude` | Where session logs and per-session buffers live. Also holds the `setup.stamp` and `quality-cache.tsv` files. |
 
 ### Slash commands
 
-The plugin ships a trimmed surface of 12 first-class verbs. `/akm-add` and `/akm-save` are no longer part of the slash-command surface — both `akm add` and `akm save` are reachable via `/akm-help` (see "When to use what" below).
+The plugin ships 18 first-class verbs. `/akm-add` and `/akm-save` are not part of the slash-command surface — both `akm add` and `akm save` are reachable via `/akm-help` (see "When to use what" below).
 
 - `/akm-search <query> [flags]` — run `akm search` directly from Claude.
 - `/akm-show <ref> [view args]` — inspect a stash asset by ref.
@@ -154,12 +158,18 @@ The plugin ships a trimmed surface of 12 first-class verbs. `/akm-add` and `/akm
 - `/akm-wiki <subcommand> [args]` — manage AKM wikis (create, register, list, show, pages, search, stash, lint, ingest, remove).
 - `/akm-workflow <subcommand> [args]` — drive workflow runs (start, next, complete, status, list, create, resume, template).
 - `/akm-vault <list|show|load> [ref]` — vault read paths: enumerate vaults, show key names, or emit a shell-eval `load` snippet. `show`/`list` never echo values; `load` output is opaque shell text meant for `eval` and is never displayed back in chat.
+- `/akm-proposal <list|show|diff|accept|reject> [id] [--reason "..."]` — operate the v0.7.0 proposal queue. Always confirms with the user before `accept`/`reject`.
+- `/akm-review-proposals [--limit N]` — list every pending proposal and diff each one in a single pass for review.
+- `/akm-reflect [ref] [--task "..."]` — generate a reflection proposal via the configured agent CLI; output lands in the proposal queue.
+- `/akm-propose <type> <name> --task "..."` — generate a new-asset proposal via the configured agent CLI.
+- `/akm-distill <ref>` — distill a ref into a proposed `lesson` (gated by `llm.features.feedback_distillation`).
+- `/akm-setup [--force]` — detect installed agent CLIs and persist `agent.default`. Required once per machine for reflect/propose.
 - `/akm-help [task]` — surface a curated quick-reference for non-first-class `akm` verbs and fall back to live `akm --help`.
 
 ### When to use what
 
-- **Prefer the 12 slash commands above** for the verbs they cover — they wire the AKM skill flow, hooks, and feedback loop together for you.
-- **For everything else** — `add` (install kits / register sources), `save`, `import`, `clone`, `update`, `remove`, `list` (sources), `registry-search`, `reindex`, `config`, `upgrade`, `run-script`, and vault writes (`create`, `set`, `unset`) — call `/akm-help <task>` first to discover the right `akm` CLI invocation, then run it via Bash.
+- **Prefer the 18 slash commands above** for the verbs they cover — they wire the AKM skill flow, hooks, and feedback loop together for you.
+- **For everything else** — `add` (install kits / register sources), `save`, `import`, `clone`, `update`, `remove`, `list` (sources), `registry-search`, `reindex`, `config`, `upgrade`, `run-script`, raw `agent` (one-shot agent shell-out), and vault writes (`create`, `set`, `unset`) — call `/akm-help <task>` first to discover the right `akm` CLI invocation, then run it via Bash.
 - **Vault writes still bypass the chat turn entirely.** `/akm-vault` is read-only for displayed output (`list` and `show` of key names; `load` produces shell-eval text that must be piped to `eval` rather than displayed); to create vaults or set/unset values, run `akm vault …` in the shell directly so secret values never pass through the chat turn.
 
 ## Docs

--- a/claude/commands/akm-distill.md
+++ b/claude/commands/akm-distill.md
@@ -1,0 +1,15 @@
+---
+description: Distill an AKM ref into a proposed `lesson` asset using the bounded in-tree LLM.
+argument-hint: <ref>
+---
+
+Parse `"$ARGUMENTS"` as a single `[origin//]type:name` ref. Most often `memory:claude-session-…` or `knowledge:<name>`, but any ref akm recognizes is accepted.
+
+1. Distill is gated by `llm.features.feedback_distillation` (default `false`). Check the gate: `akm --format json -q config get llm.features.feedback_distillation`. If the value is not `true`:
+   - Tell the user the gate is off and what flipping it implies (LLM tokens cost money; bounded 30 s timeout per call; output goes to the proposal queue, not live content).
+   - **Confirm with the user** before flipping it. Only then run `akm --format json -q config set llm.features.feedback_distillation true`.
+2. Run `akm --format json -q distill <ref>`. The wrapper produces a `lesson` proposal with required `description` and `when_to_use` frontmatter and queues it under `<stashRoot>/.akm/proposals/<id>/`.
+3. If the gated call returns a fallback (e.g. timeout, throw), report the warning verbatim — no proposal will have been queued.
+4. On success, surface the proposal id, the distilled `description`, and route the user through `/akm-proposal show <id>` → `/akm-proposal diff <id>` → `/akm-proposal accept <id>`.
+
+Lessons are stored under `lessons/<name>.md` after acceptance and become first-class searchable assets (`lesson:<name>`).

--- a/claude/commands/akm-proposal.md
+++ b/claude/commands/akm-proposal.md
@@ -1,0 +1,18 @@
+---
+description: Operate the AKM v0.7.0 proposal queue — list, show, diff, accept, or reject pending drafts.
+argument-hint: <list|show|diff|accept|reject> [id] [--reason "..."]
+---
+
+Parse `"$ARGUMENTS"`. The first token is the action (`list`, `show`, `diff`, `accept`, `reject`); the second token (when present) is the proposal id; remaining tokens are flags forwarded to the CLI.
+
+Routing:
+
+- **list** — `akm --format json -q proposal list`. Forward `--status pending|accepted|rejected` if the user passed it. Render a table of `id`, `ref`, `status`, `kind`, `createdAt`.
+- **show** — `akm --format json -q proposal show <id>`. Render the proposal body and any validation warnings.
+- **diff** — `akm --format json -q proposal diff <id>`. Render the diff against the live ref so the user can see what would change on accept.
+- **accept** — **Confirm with the user before running.** Acceptance promotes a draft into curated content via the same `writeAssetToSource()` write path as `akm remember` and `akm import`. Then run `akm --format json -q proposal accept <id>`. If validation fails the proposal stays `pending`; surface the `warnings` array verbatim.
+- **reject** — **Confirm with the user before running.** Rejection archives the proposal under `<stashRoot>/.akm/proposals/archive/<id>/`. Then run `akm --format json -q proposal reject <id> --reason "<reason>"`. Always require a non-empty reason; ask the user if missing.
+
+If the user runs `/akm-proposal` with no arguments, default to `list --status pending`.
+
+After any state-changing call (`accept` / `reject`), report the resulting status and the affected ref so the user can verify.

--- a/claude/commands/akm-propose.md
+++ b/claude/commands/akm-propose.md
@@ -1,0 +1,13 @@
+---
+description: Generate a new-asset proposal via the configured agent CLI; the result lands in the proposal queue.
+argument-hint: <type> <name> --task "what the asset should do"
+---
+
+Parse `"$ARGUMENTS"` as `<type> <name>` followed by required flag `--task "..."`. `<type>` is one of `skill`, `command`, `agent`, `knowledge`, `lesson`, `script`, `workflow`, `wiki`. `<name>` follows the standard ref slug grammar (`[A-Za-z0-9._/\-]+`).
+
+1. Verify `agent.default` is configured: `akm --format json -q config get agent.default`. If empty, suggest `/akm-setup` and stop.
+2. Confirm the slug is not already taken: `akm --format json -q show <type>:<name>`. If the asset exists, ask the user whether to pick a different name or use `/akm-reflect <ref>` to revise the existing one.
+3. Run `akm --format json -q propose <type> <name> --task "..."`. The configured agent CLI drafts the asset and writes it as a `quality:"proposed"` proposal — it never lands in curated content directly.
+4. Surface the proposal id and a one-line summary; route the user through `/akm-proposal show <id>` → `/akm-proposal diff <id>` → `/akm-proposal accept <id>`.
+
+If `--task` is missing, ask the user to provide it before running.

--- a/claude/commands/akm-reflect.md
+++ b/claude/commands/akm-reflect.md
@@ -1,0 +1,12 @@
+---
+description: Generate a reflection proposal for an AKM ref via the configured agent CLI; the result lands in the proposal queue.
+argument-hint: [ref] [--task "what to reflect on"]
+---
+
+Parse `"$ARGUMENTS"` as an optional `[origin//]type:name` ref followed by optional flags (commonly `--task "..."`).
+
+1. Verify `agent.default` is configured: `akm --format json -q config get agent.default`. If empty, suggest the user run `/akm-setup` first and stop.
+2. Run `akm --format json -q reflect <ref> [--task "..."]` (omit the ref if the user only passed `--task`). The command shells out to the configured agent CLI (`opencode`, `claude`, `codex`, `gemini`, or `aider`) and writes its output to the proposal queue only — it does not mutate any live stash content.
+3. Surface the returned proposal id, kind, and a one-line summary. Tell the user to review with `/akm-proposal show <id>` and then `/akm-proposal accept <id>` or `/akm-proposal reject <id> --reason "..."`.
+
+If the agent CLI fails or times out (default 30 s), the wrapper records the error and no proposal is queued. Surface the error verbatim so the user can decide whether to retry.

--- a/claude/commands/akm-review-proposals.md
+++ b/claude/commands/akm-review-proposals.md
@@ -1,0 +1,14 @@
+---
+description: List every pending AKM proposal and diff each one in a single pass for review.
+argument-hint: [--limit N]
+---
+
+Walk the proposal queue in one pass so the user can decide accept / reject / revise:
+
+1. Run `akm --format json -q proposal list --status pending`. If the array is empty, report "No pending proposals." and stop.
+2. For each proposal in the list (cap at 10 unless the user passed `--limit`):
+   - Run `akm --format json -q proposal show <id>` and summarize the `kind`, target `ref`, and the body in 2-3 lines.
+   - Run `akm --format json -q proposal diff <id>` and surface the diff (collapsed if longer than 40 lines).
+   - List any `warnings` reported by the validator.
+3. After all entries are rendered, present a compact recommendation table per id with three columns: `id`, `ref`, `recommendation` (`accept` / `reject` / `revise`). Choose recommendations based on the diff and validation signal — flag conflicts with curated content as `revise`.
+4. **Do not call `akm proposal accept` or `akm proposal reject` from this command.** Always wait for the user to confirm and use `/akm-proposal accept <id>` or `/akm-proposal reject <id> --reason "..."`.

--- a/claude/commands/akm-setup.md
+++ b/claude/commands/akm-setup.md
@@ -1,0 +1,13 @@
+---
+description: Detect installed agent CLIs and persist `agent.default` so reflect/propose/distill can shell out.
+argument-hint: [--force]
+---
+
+Run `akm setup` to detect the local agent CLI surface and persist `agent.default` in the config.
+
+1. Run `akm --format json -q setup`. The command probes for `opencode`, `claude`, `codex`, `gemini`, and `aider` on PATH and records the first one it finds as `agent.default`.
+2. Surface the detected agent (or report "no agent CLI found on PATH" and stop).
+3. If the user passed `--force`, append `--force` to the call so it re-runs detection even when `agent.default` is already set.
+4. After running, confirm by reading back `akm --format json -q config get agent.default`. Mention that the SessionStart hook also performs this check on first run, gated by a stamp file under the plugin state dir.
+
+Without an agent CLI on PATH, `/akm-reflect` and `/akm-propose` cannot generate proposals. Suggest the user install one (e.g. `bun install -g opencode-ai`) and rerun `/akm-setup --force`.

--- a/claude/hooks/akm-hook.sh
+++ b/claude/hooks/akm-hook.sh
@@ -4,23 +4,26 @@ set -eu
 
 COMMAND="${1:-}"
 MODE="${2:-}"
-PACKAGE_REF="akm-cli@latest"
+PACKAGE_REF="${AKM_PACKAGE_REF:-akm-cli@latest}"
 STATE_DIR="${AKM_PLUGIN_STATE_DIR:-${XDG_STATE_HOME:-${HOME:-.}/.local/state}/akm-claude}"
 SESSIONS_DIR="$STATE_DIR/sessions"
 SESSION_LOG="$STATE_DIR/session.log"
 FEEDBACK_LOG="$STATE_DIR/feedback.log"
 MEMORY_LOG="$STATE_DIR/memory.log"
+QUALITY_CACHE="$STATE_DIR/quality-cache.tsv"
+SETUP_STAMP="$STATE_DIR/setup.stamp"
 CURATE_LIMIT="${AKM_CURATE_LIMIT:-5}"
 CURATE_MIN_CHARS="${AKM_CURATE_MIN_CHARS:-16}"
 CURATE_TIMEOUT="${AKM_CURATE_TIMEOUT:-8}"
 CONTEXT_BUDGET_CHARS="${AKM_CONTEXT_BUDGET_CHARS:-4000}"
 AUTO_FEEDBACK="${AKM_AUTO_FEEDBACK:-1}"
 AUTO_MEMORY="${AKM_AUTO_MEMORY:-1}"
+AUTO_SETUP="${AKM_AUTO_SETUP:-1}"
 INDEX_ON_SESSION_END="${AKM_INDEX_ON_SESSION_END:-0}"
 CURATED_PROMPT_HEADER="# AKM stash — assets relevant to this prompt"
 CURATED_SESSION_HEADER="# AKM stash — assets relevant to this session"
 CURATED_CONTEXT_TAIL="Tip: call \`akm show <ref>\` to fetch full content, and record \`akm feedback <ref> --positive|--negative\` once you know whether the asset helped."
-SESSION_START_FOOTER="For verbs not covered by a slash command (save, import, clone, update, remove, list-sources, registry-search, reindex, config, upgrade, run-script, vault writes, …), run \`/akm-help\` first to discover the right \`akm\` CLI invocation, then run it via Bash."
+SESSION_START_FOOTER="For verbs not covered by a slash command (save, import, clone, update, remove, list-sources, registry-search, reindex, config, upgrade, run-script, vault writes, agent, setup, …), run \`/akm-help\` first to discover the right \`akm\` CLI invocation, then run it via Bash. v0.7.0 adds the \`/akm-proposal\`, \`/akm-reflect\`, \`/akm-propose\`, \`/akm-distill\`, \`/akm-review-proposals\`, and \`/akm-setup\` slash commands for the proposal queue and agent-CLI integration."
 SESSION_START_HEADER="$(cat <<'EOF'
 # AKM is available in this session
 
@@ -138,6 +141,100 @@ akm_run() {
   else
     akm "$@" 2>/dev/null || true
   fi
+}
+
+# Resolve the asset quality for a ref via `akm show <ref> --format json`.
+# Echoes one of {generated, curated, proposed, unknown}. Caches results in
+# QUALITY_CACHE so a single hook process doesn't re-shell out per ref. We do
+# not crash on parse errors — unknown values pass through (parse-warn-include
+# is the v0.7.0 contract).
+ref_quality() {
+  ref="$1"
+  [ -n "$ref" ] || { printf 'unknown\n'; return 0; }
+
+  if [ -f "$QUALITY_CACHE" ]; then
+    cached="$(grep -F "	$ref	" "$QUALITY_CACHE" 2>/dev/null | tail -n 1 | cut -f3)"
+    if [ -n "$cached" ]; then
+      printf '%s\n' "$cached"
+      return 0
+    fi
+  fi
+
+  raw="$(akm_run --format json -q show "$ref")"
+  quality="$(printf '%s' "$raw" | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    print("unknown")
+    sys.exit(0)
+q = data.get("quality") if isinstance(data, dict) else None
+if not isinstance(q, str) or not q:
+    print("unknown")
+else:
+    print(q)
+' 2>/dev/null || printf 'unknown')"
+
+  printf '%s\t%s\t%s\n' "$(timestamp)" "$ref" "$quality" >> "$QUALITY_CACHE" 2>/dev/null || true
+  printf '%s\n' "$quality"
+}
+
+# Detect and persist agent.default via `akm setup`. Idempotent — guarded by a
+# stamp file so we only run once per machine unless AKM_AUTO_SETUP=force.
+detect_agent_default() {
+  akm_available || { printf '\n'; return 0; }
+
+  current="$(akm_run --format json -q config get agent.default 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "null")
+except Exception:
+    print("")
+    sys.exit(0)
+if isinstance(data, str):
+    print(data)
+elif isinstance(data, dict):
+    val = data.get("value") or data.get("agent.default") or ""
+    print(val if isinstance(val, str) else "")
+else:
+    print("")
+' 2>/dev/null || printf '')"
+
+  if [ -n "$current" ]; then
+    printf '%s\n' "$current"
+    return 0
+  fi
+
+  if [ "$AUTO_SETUP" != "1" ] && [ "$AUTO_SETUP" != "force" ]; then
+    printf '\n'
+    return 0
+  fi
+
+  if [ -f "$SETUP_STAMP" ] && [ "$AUTO_SETUP" != "force" ]; then
+    printf '\n'
+    return 0
+  fi
+
+  akm_run --format json -q setup >/dev/null
+  printf '%s' "$(timestamp)" > "$SETUP_STAMP" 2>/dev/null || true
+  append_log "$SESSION_LOG" "akm_setup" "auto"
+
+  detected="$(akm_run --format json -q config get agent.default 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "null")
+except Exception:
+    print("")
+    sys.exit(0)
+if isinstance(data, str):
+    print(data)
+elif isinstance(data, dict):
+    val = data.get("value") or data.get("agent.default") or ""
+    print(val if isinstance(val, str) else "")
+else:
+    print("")
+' 2>/dev/null || printf '')"
+  printf '%s\n' "$detected"
 }
 
 run_index_on_session_end() {
@@ -316,8 +413,9 @@ combined = "\n".join(part for part in (command, output) if part)
 
 # Detect any asset ref that akm might know about. Ref grammar from the skill:
 #   [origin//]type:name   where type ∈ {skill, command, agent, knowledge, memory,
-#                                       script, workflow, vault, wiki}
-ref_pattern = re.compile(r"(?:[A-Za-z0-9@._+/-]+//)?(?:skill|command|agent|knowledge|memory|script|workflow|vault|wiki):[A-Za-z0-9._/-]+")
+#                                       lesson, script, workflow, vault, wiki}
+# `lesson` is the v0.7.0 first-class type produced by `akm distill`.
+ref_pattern = re.compile(r"(?:[A-Za-z0-9@._+/-]+//)?(?:skill|command|agent|knowledge|memory|lesson|script|workflow|vault|wiki):[A-Za-z0-9._/-]+")
 refs = set(ref_pattern.findall(combined))
 
 if not refs and "akm remember" in command:
@@ -427,7 +525,16 @@ auto_feedback() {
     case "$ref" in
       memory:*) continue ;;  # memories don't take feedback today
       vault:*) continue ;;   # vault values never surface — feedback is noise
+      lesson:*) continue ;;  # lessons land via the proposal queue; feedback flows through `akm proposal`
+      *//memory:*|*//vault:*|*//lesson:*) continue ;;
     esac
+    quality="$(ref_quality "$ref")"
+    if [ "$quality" = "proposed" ]; then
+      # Proposed assets aren't curated content yet — feedback would route to a
+      # draft that may be rejected. Skip until promotion via `akm proposal accept`.
+      append_log "$FEEDBACK_LOG" "system" "skip_proposed" "$ref" "$status_text"
+      continue
+    fi
     akm_run --format json -q feedback "$ref" "$sentiment_flag" --note "$note" >/dev/null
   done
   IFS="${OLD_IFS}"
@@ -482,11 +589,41 @@ session_start() {
   # Keep the index warm in the background — never block session start.
   ( akm_run index >/dev/null & ) 2>/dev/null || true
 
+  agent_default="$(detect_agent_default)"
   hints="$(akm_run --format text -q hints)"
   curated="$(akm_run --detail agent --format text -q curate --limit "$CURATE_LIMIT" $(build_run_scope_args "$sid"))"
-  [ -n "$(printf '%s' "$hints" | tr -d ' \t\n\r')" ] || [ -n "$(printf '%s' "$curated" | tr -d ' \t\n\r')" ] || exit 0
+  pending_summary="$(akm_run --format json -q proposal list --status pending 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.loads(sys.stdin.read() or "null")
+except Exception:
+    print("")
+    sys.exit(0)
+if not isinstance(data, dict):
+    print("")
+    sys.exit(0)
+items = data.get("proposals") or data.get("hits") or []
+n = len(items) if isinstance(items, list) else 0
+if n <= 0:
+    print("")
+elif n == 1:
+    print("There is 1 pending AKM proposal — review with `/akm-review-proposals` or `/akm-proposal list`.")
+else:
+    print(f"There are {n} pending AKM proposals — review with `/akm-review-proposals` or `/akm-proposal list`.")
+' 2>/dev/null || printf '')"
+  [ -n "$(printf '%s' "$hints" | tr -d ' \t\n\r')" ] \
+    || [ -n "$(printf '%s' "$curated" | tr -d ' \t\n\r')" ] \
+    || [ -n "$agent_default" ] \
+    || [ -n "$pending_summary" ] \
+    || exit 0
 
   body="$SESSION_START_HEADER"
+  if [ -n "$agent_default" ]; then
+    body="$(printf '%s\n\nAgent CLI: %s (configured via `akm setup`).' "$body" "$agent_default")"
+  fi
+  if [ -n "$pending_summary" ]; then
+    body="$(printf '%s\n\n%s' "$body" "$pending_summary")"
+  fi
   if [ -n "$(printf '%s' "$hints" | tr -d ' \t\n\r')" ]; then
     body="$(printf '%s\n\n%s' "$body" "$hints")"
   fi

--- a/claude/package.json
+++ b/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akm-claude",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Claude Code plugin for AKM skills and hooks.",
   "license": "MPL-2.0",

--- a/claude/skills/akm/SKILL.md
+++ b/claude/skills/akm/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: akm
-description: Search, show, dispatch agents, execute commands, run workflows, manage wikis and vaults, and curate stash assets via the akm CLI. Use when the user wants to find or use tools, skills, commands, agents, knowledge, wikis, vaults, or workflows.
+description: Search, show, dispatch agents, execute commands, run workflows, manage wikis and vaults, route the proposal queue, distill lessons, and curate stash assets via the akm CLI. Use when the user wants to find or use tools, skills, commands, agents, knowledge, lessons, wikis, vaults, or workflows.
 ---
 
 # AKM Stash
 
-You have access to the `akm` CLI (AKM, v0.6.1+) to manage extension assets from a stash directory.
+You have access to the `akm` CLI (AKM, v0.7.0+) to manage extension assets from a stash directory.
 
 ## Tool surface vs. CLI
 
-The Claude AKM plugin exposes **12 first-class slash commands** for the high-value verbs:
+The Claude AKM plugin exposes **18 first-class slash commands** for the high-value verbs:
 
 - `/akm-search` — search the stash or registry
 - `/akm-show` — fetch the full payload for a ref
@@ -22,13 +22,19 @@ The Claude AKM plugin exposes **12 first-class slash commands** for the high-val
 - `/akm-wiki` — wiki create/register/list/show/pages/search/stash/lint/ingest/remove
 - `/akm-workflow` — start/next/complete/status/list/create/resume/template
 - `/akm-vault` — vault `list` / `show` (key names) / `load` (shell-eval snippet)
+- `/akm-proposal` — operate the v0.7.0 proposal queue (list/show/diff/accept/reject)
+- `/akm-review-proposals` — list and diff every pending proposal in one pass
+- `/akm-reflect` — generate a reflection proposal via the configured agent CLI
+- `/akm-propose` — generate a new-asset proposal via the configured agent CLI
+- `/akm-distill` — distill a ref into a `lesson` proposal (gated by `llm.features.feedback_distillation`)
+- `/akm-setup` — detect installed agent CLIs and persist `agent.default`
 - `/akm-help` — discover the right raw `akm` invocation for the long tail
 
 For every other verb — `add` (install kits / register sources), `save`, `import`, `clone`,
 `update`, `remove` (uninstall a source), `list` (configured sources), `registry search`,
-`index` (reindex), `config`, `upgrade`, ad-hoc `run`, vault writes (`set` / `unset`), and
-any flag not exposed by the slash commands above — **call `/akm-help` first** to discover
-the right `akm` CLI form, then run it via Bash.
+`index` (reindex), `config`, `upgrade`, ad-hoc `run`, `agent` (raw agent-CLI shell-out),
+vault writes (`set` / `unset`), and any flag not exposed by the slash commands above —
+**call `/akm-help` first** to discover the right `akm` CLI form, then run it via Bash.
 
 ### akm_help quick reference
 
@@ -67,10 +73,12 @@ The stash directory contains:
 - **agents/** — markdown agent definition files
 - **knowledge/** — markdown knowledge files
 - **memories/** — markdown memory files recorded with `akm remember`
+- **lessons/** — markdown lesson files (`lesson:<name>`) with required `description` and `when_to_use` frontmatter; normally produced by `akm distill <ref>` as a proposed-quality proposal and promoted via `akm proposal accept`
 - **scripts/** — executable scripts (.sh, .ts, .js, .ps1, .cmd, .bat, .py, .rb, .go, .pl, .php, .lua, .r, .swift, .kt)
 - **workflows/** — multi-step procedures (`workflow:<name>`) driven by `akm workflow`
 - **vaults/** — `.env` files (`vault:<name>`) whose values are managed by `akm vault` and **never** surface in JSON, logs, or search indexes
 - **wikis/** — per-wiki directories (`<stashDir>/wikis/<name>/`) containing `schema.md`, `index.md`, `log.md`, `raw/`, and agent-authored pages referenced as `wiki:<name>/<page>`
+- **.akm/proposals/** — v0.7.0 proposal queue (one directory per proposal). Drafts here never leak into search or commits; promote them with `akm proposal accept <id>`.
 
 ### Multi-source resolution
 
@@ -87,7 +95,16 @@ Assets are classified using a multi-signal matcher system that considers file ex
 
 ### Refs
 
-Refs use the format `[origin//]type:name`. Simple refs like `script:deploy.sh` search all sources. Origin-qualified refs like `npm:@scope/pkg//script:deploy.sh` or `local//script:deploy.sh` target a specific source.
+Refs use the format `[origin//]type:name`. The known types are `skill`, `command`, `agent`, `knowledge`, `memory`, `lesson`, `script`, `workflow`, `vault`, and `wiki`. Simple refs like `script:deploy.sh` search all sources. Origin-qualified refs like `npm:@scope/pkg//script:deploy.sh` or `local//script:deploy.sh` target a specific source.
+
+### Quality
+
+`SearchHit.quality` is an open string set with three well-known values:
+- `"curated"` — accepted into the stash; included in default search.
+- `"generated"` — auto-generated but accepted; included in default search.
+- `"proposed"` — drafts in the proposal queue; **excluded from default search** and only surface via `akm search ... --include-proposed` or `akm proposal *`.
+
+Unknown quality values parse-warn-include (they remain searchable). Treat `proposed` assets as candidates only — never feed them through `akm feedback` until they are promoted via `/akm-proposal accept`. The plugin's auto-feedback hook automatically skips proposed-quality refs.
 
 ## Commands
 
@@ -106,16 +123,17 @@ Use `--full` to force a full reindex instead of incremental. Run this after addi
 Find assets using a hybrid search pipeline: semantic embeddings + TF-IDF ranking. Falls back to name substring matching when no index exists.
 
 ```bash
-akm search [query] [--type skill|command|agent|knowledge|memory|script|workflow|vault|wiki|any] [--limit N] [--source stash|local|registry|both]
+akm search [query] [--type skill|command|agent|knowledge|memory|lesson|script|workflow|vault|wiki|any] [--limit N] [--source stash|local|registry|both] [--include-proposed]
 ```
 
 Square brackets denote optional arguments; pipe-separated values denote allowed choices for a single flag.
 
 The response includes `hits` (ranked results), plus diagnostic fields: `timing` (totalMs, rankMs, embedMs), `warnings` (string array of non-fatal issues), and `tip` (contextual usage hint).
 
-- Local and installed stash hits include `ref`, which you pass to `akm show`.
-- Registry hits include `id`, `installRef`, `action` (contains install guidance), and `curated` fields.
+- Local and installed stash hits include `ref`, which you pass to `akm show`. Hits also include optional `quality?` (`curated` / `generated` / `proposed` / unknown) and `warnings?` (string array of non-fatal issues).
+- Registry hits live under a separate `registryHits` key and include `id`, `installRef`, `action` (contains install guidance). The legacy `curated` boolean is removed in v0.7.0; use the per-asset `quality` field instead.
 - Use `--source registry` when the user is looking for installable community kits, or `--source both` to search everything at once. Note: `local` remains a backward-compatible alias for `stash`.
+- `--include-proposed` merges `quality:"proposed"` rows into `hits`; without it, drafts in the proposal queue are hidden from default search.
 
 ### Show an asset
 
@@ -214,6 +232,98 @@ akm feedback skill:code-review --positive
 akm feedback command:release --negative --note "Outdated for the current repo layout"
 ```
 
+Auto-feedback (recorded by the plugin hooks on Bash tool success/failure) skips
+`memory:*`, `vault:*`, `lesson:*`, and any ref the indexer reports as
+`quality:"proposed"`. Lessons take feedback through the proposal queue, not via
+direct `akm feedback`. Override an automatic signal by running `akm feedback`
+explicitly.
+
+## Proposal queue (v0.7.0)
+
+All proposal-producing commands (`akm reflect`, `akm propose`, `akm distill`,
+plus any plugin-emitted proposals) write through one durable queue at
+`<stashRoot>/.akm/proposals/`. Drafts there never leak into search or commits;
+acceptance runs full validation before routing through the same single write
+path used by `akm remember` and `akm import`.
+
+```bash
+akm proposal list                       # all pending drafts
+akm proposal list --status pending --format json
+akm proposal show <id>                  # render the draft
+akm proposal diff <id>                  # diff vs. the live ref
+akm proposal accept <id>                # validate, then promote
+akm proposal reject <id> --reason "…"   # archive with reason
+```
+
+Use the slash commands rather than the raw CLI:
+
+- `/akm-review-proposals` — list every pending proposal and diff each one.
+- `/akm-proposal list|show|diff` — read-only operations.
+- `/akm-proposal accept|reject` — **always confirm with the user before running.** Acceptance promotes a draft into curated content; rejection archives it.
+
+Multiple proposals for the same `ref` coexist without filesystem collisions.
+The default `quality` for promoted proposals is set by the proposal itself (most
+commonly `curated` after acceptance). To search drafts directly, run
+`akm search "<query>" --include-proposed`.
+
+## Lessons
+
+`lesson` is a first-class v0.7.0 asset type stored under `<stashDir>/lessons/<name>.md`.
+Frontmatter is required:
+
+```markdown
+---
+description: One-line summary of the lesson.
+when_to_use: When this insight applies (problem context, signals, etc.).
+---
+
+Body in markdown.
+```
+
+The canonical creation path is **`/akm-distill <ref>`** — run it on a memory,
+knowledge doc, or session summary that contains repeated evidence. `distill`
+emits a `lesson` proposal at `quality:"proposed"` which the user then reviews
+via `/akm-proposal accept`. Direct authoring via `akm import` and `akm
+remember`-style flows is also supported.
+
+Distill is gated behind `llm.features.feedback_distillation` (default `false`).
+If the gate is off, `/akm-distill` falls back gracefully — confirm with the
+user before flipping the gate via `akm config set llm.features.feedback_distillation true`.
+
+## Reflect / Propose
+
+`/akm-reflect` and `/akm-propose` shell out to the configured agent CLI
+(`agent.default`, set up via `/akm-setup`) and write **only** to the proposal
+queue — they never mutate live stash content. Use them when:
+
+- An asset misbehaved and you want a corrective draft → `/akm-reflect <ref> [--task "..."]`.
+- A coverage gap appeared in the conversation and you want a new draft asset → `/akm-propose <type> <name> --task "..."`.
+
+If `agent.default` is unset, run `/akm-setup` first; the plugin's SessionStart
+hook does this automatically on first run when an agent CLI is detected on
+PATH.
+
+## In-tree LLM gates
+
+Every bounded in-tree LLM call site is gated behind exactly one feature flag
+in `llm.features.*`. All defaults are `false`. The seven keys:
+
+| Key | Use site |
+| --- | --- |
+| `curate_rerank` | LLM rerank in `akm curate` |
+| `tag_dedup` | LLM tag dedup during indexer enrichment |
+| `memory_consolidation` | `akm remember --enrich` consolidation |
+| `feedback_distillation` | `akm distill <ref>` |
+| `embedding_fallback_score` | scorer fallback when embeddings unavailable |
+| `memory_inference` | indexer split of pending memories into atomic facts |
+| `graph_extraction` | indexer entity/relation extraction → `graph.json` |
+
+Every gated call site uses `tryLlmFeature(...)` from akm core: when the gate
+is `false`, the function never runs; when it throws or times out (30 s
+default), the caller's fallback runs and a `warnings` entry is emitted. Don't
+flip these flags without the user's explicit consent — they cost LLM tokens
+and may emit network traffic.
+
 ## Compound engineering loop
 
 This plugin closes the loop between **using** assets and **improving** them so
@@ -223,15 +333,17 @@ intent-bearing parts.
 
 | Phase | Automatic (hooks) | Your responsibility |
 | --- | --- | --- |
-| Session start | `akm` installed/refreshed; `akm hints` injected as context; index warmed in the background. | Skim the hints so you know which asset types are available. |
+| Session start | `akm` installed/refreshed; `agent.default` detected and persisted via `akm setup` on first run; pending proposal count surfaced; `akm hints` injected as context; index warmed in the background. | Skim the hints, agent CLI, and any pending-proposal headline so you know what's queued. |
 | Each user prompt | `akm curate "<prompt>"` runs and its top matches are injected into context as `additionalContext`. | Prefer the curated assets over writing new code; fetch full payloads with `akm show <ref>` before using. |
-| Each Bash tool call | Asset refs in the command/output are logged and positive/negative feedback is recorded automatically on success/failure. | When the automatic signal is wrong (e.g. the ref was in a discussion, not actually used), correct with an explicit `akm feedback`. |
-| Session or subagent stops; before compaction | The session buffer (memory intents + refs used) is persisted as `memory:claude-session-YYYYMMDD-<sid>`. | Promote durable learnings from that memory into a named skill/knowledge doc via `/akm-remember` or the `akm-curator` agent. |
+| Each Bash tool call | Asset refs in the command/output are logged. Auto-feedback skips `memory:*` / `vault:*` / `lesson:*` / `quality:"proposed"` refs and records positive/negative feedback for everything else on success/failure. | When the automatic signal is wrong (e.g. the ref was in a discussion, not actually used), correct with an explicit `akm feedback`. |
+| Session or subagent stops; before compaction | The session buffer (memory intents + refs used) is persisted as `memory:claude-session-YYYYMMDD-<sid>`. | Promote durable learnings — distill the session memory into a `lesson` via `/akm-distill memory:<name>`, review the resulting proposal, and accept it via `/akm-proposal accept <id>`. |
 
 When you discover a pattern worth keeping, **write it back to the stash**
 rather than only answering the user. Options:
 
 - `/akm-remember` (or `akm remember --name <slug>`) — short markdown note (reads stdin).
+- `/akm-distill <ref>` — distill repeated evidence into a `lesson` proposal; review and accept via `/akm-proposal accept`.
+- `/akm-reflect <ref>` / `/akm-propose <type> <name> --task "..."` — generate a corrective or new-asset proposal via the configured agent CLI. Both write only to the proposal queue.
 - `akm import <file>` — promote a drafted file into the knowledge index. Run `/akm-help`
   topic="import" if you need a refresher on the flag surface.
 - `akm clone <ref>` + edit — fork an existing asset, then rewrite with your

--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,6 +1,6 @@
 # akm-opencode
 
-OpenCode plugin for the [AKM](https://github.com/itlackey/akm) CLI (v0.6.1+). Registers tools that let your AI agent **search**, **show**, and **manage** stash assets — skills, commands, agents, knowledge, memories, scripts, workflows, vaults, and wikis — plus **agentic hooks** that auto-load relevant assets into each turn, record feedback when assets are used, and harvest session memories so the stash improves with every session.
+OpenCode plugin for the [AKM](https://github.com/itlackey/akm) CLI (v0.7.0+). Registers tools that let your AI agent **search**, **show**, and **manage** stash assets — skills, commands, agents, knowledge, memories, lessons, scripts, workflows, vaults, and wikis — **operate the v0.7.0 proposal queue** and **distill lessons** through dedicated tools, plus **agentic hooks** that auto-load relevant assets into each turn, record feedback when assets are used (skipping proposed-quality drafts), and harvest session memories so the stash improves with every session.
 
 ## Installation
 
@@ -14,7 +14,7 @@ Add to your OpenCode config (`opencode.json`):
 
 ## Tools
 
-The plugin exposes a trimmed surface of **14 high-value tools**. Long-tail verbs (`add`, `save`, `import`, `clone`, `update`, `remove`, `list`-sources, `registry-search`, `index`-reindex, `config`, `upgrade`, ad-hoc `run`, `proposal`, `distill`, `reflect`, `propose`) are reachable via `akm_help` plus the raw `akm` CLI through the `bash` tool.
+The plugin exposes **19 high-value tools**. Long-tail verbs (`add`, `save`, `import`, `clone`, `update`, `remove`, `list`-sources, `registry-search`, `index`-reindex, `config`, `upgrade`, ad-hoc `run`, raw `agent`) are reachable via `akm_help` plus the raw `akm` CLI through the `bash` tool.
 
 | Tool | Description |
 |------|-------------|
@@ -23,7 +23,7 @@ The plugin exposes a trimmed surface of **14 high-value tools**. Long-tail verbs
 | `akm_agent` | Dispatch a stash `agent:*` into OpenCode using the stash prompt and metadata |
 | `akm_cmd` | Execute a stash `command:*` template in OpenCode via SDK session prompting |
 | `akm_remember` | Record a memory in the default stash |
-| `akm_feedback` | Record positive or negative feedback for a stash asset (skipped automatically for `memory:` and `vault:` refs) |
+| `akm_feedback` | Record positive or negative feedback for a stash asset (skipped automatically for `memory:`, `vault:`, `lesson:`, and proposed-quality refs) |
 | `akm_curate` | Curate the stash for a task or topic and return ranked matches the agent can use |
 | `akm_evolve` | Dispatch the AKM curator subagent into a child session, capture the report as a memory, and seed the curator-context cache so it survives compaction |
 | `akm_parent_messages` | Summarize the parent OpenCode session so dispatched stash subagents can inherit upstream context |
@@ -31,6 +31,11 @@ The plugin exposes a trimmed surface of **14 high-value tools**. Long-tail verbs
 | `akm_vault` | Vault `list` / `show` (key names) / `create` / `set` / `unset` / `load` (opaque shell-eval text). **Values never surface** through `list`/`show`; `load` output is meant for `eval` and must not be displayed back |
 | `akm_wiki` | Manage wikis (`create`, `register`, `list`, `show`, `pages`, `search`, `stash`, `lint`, `ingest`, `remove`) |
 | `akm_workflow` | Drive workflow runs (`start`, `next`, `complete`, `status`, `list`, `create`, `template`, `resume`) |
+| `akm_proposal` | Operate the v0.7.0 proposal queue (`list` / `show` / `diff` / `accept` / `reject`). Always confirm with the user before `accept`/`reject` — those operations require explicit approval |
+| `akm_reflect` | Generate a reflection proposal via the configured agent CLI; output lands in the proposal queue only |
+| `akm_propose` | Generate a new-asset proposal via the configured agent CLI; the result is `quality:"proposed"` until accepted |
+| `akm_distill` | Distill an AKM ref (typically `memory:*` or `knowledge:*`) into a proposed `lesson` (gated by `llm.features.feedback_distillation`) |
+| `akm_setup` | Detect installed agent CLIs (`opencode`, `claude`, `codex`, `gemini`, `aider`) and persist `agent.default`. Required once per machine for `akm_reflect` / `akm_propose` |
 | `akm_help` | Discover the right `akm` CLI invocation for non-first-class verbs. Returns a curated quick-reference table plus live `akm <subcommand> --help` output |
 
 ## Compound-engineering hooks
@@ -69,6 +74,7 @@ fails silently when `akm` is not on PATH — the TUI is never affected.
 | `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` | `\b(thanks|perfect|worked)\b` | Case-insensitive regex used for lightweight positive retrospective feedback on the most recent refs. |
 | `AKM_RETROSPECTIVE_NEGATIVE_PATTERN` | `\b(wrong|failed|broken|didn't work|did not work|bad)\b` | Case-insensitive regex used for negative retrospective feedback signals. |
 | `AKM_PENDING_PROPOSAL_TIMEOUT` | `2` | Seconds allowed for lightweight pending-proposal count checks during context injection. |
+| `AKM_PACKAGE_REF` | `akm-cli@latest` | Override the npm/bun package spec used for auto-install (e.g. pin to `akm-cli@0.7.0` in CI). |
 
 ### Curator agent
 
@@ -168,9 +174,11 @@ stash/
 ├── agents/     # markdown files
 ├── knowledge/  # markdown files
 ├── memories/   # markdown memory files (akm remember)
+├── lessons/    # first-class durable learnings (lesson:<name>) — produced by akm distill, accepted via akm_proposal accept
 ├── workflows/  # multi-step procedures (workflow:<name>)
 ├── vaults/     # .env secret stores (vault:<name>) — values never surface through structured output
-└── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
+├── wikis/      # per-wiki directories <name>/{schema,index,log}.md + raw/ + pages
+└── .akm/proposals/  # v0.7.0 proposal queue — drafts that never leak into search or commits
 ```
 
 ## Vaults

--- a/opencode/index.ts
+++ b/opencode/index.ts
@@ -5,7 +5,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 let resolvedAkmCommand = "akm"
-const autoInstallPackageRef = "akm-cli@latest"
+const autoInstallPackageRef = process.env.AKM_PACKAGE_REF ?? "akm-cli@latest"
 const moduleDir = path.dirname(fileURLToPath(import.meta.url))
 const SEMVER_PATTERN = /\b\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\b/
 
@@ -59,7 +59,7 @@ let cachedAkmStashDir: string | undefined
 const AKM_REF_PATTERN = /^(?:[A-Za-z0-9@._+/-]+\/\/)?(?:skill|command|agent|knowledge|memory|script|workflow|vault|wiki|lesson):[A-Za-z0-9._/\-]+$/
 const PROPOSED_QUALITY_WARNING = "Do not treat proposed assets as curated until accepted."
 const AKM_WORKFLOW_INSTRUCTION = [
-  "# AKM workflow",
+  "# AKM workflow (v0.7.0)",
   "",
   "Use AKM as a reusable knowledge and workflow stash.",
   "",
@@ -67,10 +67,11 @@ const AKM_WORKFLOW_INSTRUCTION = [
   "1. Use `akm_search` or `akm_curate`.",
   "2. Use `akm_show <ref>` before relying on an asset.",
   "3. Record `akm_feedback` after the result is known.",
-  "4. Use `akm_help` to route long-tail AKM CLI workflows such as `proposal`, `distill`, `reflect`, and `propose`.",
-  "5. Treat `lesson:*` as first-class durable learning assets.",
-  `6. ${PROPOSED_QUALITY_WARNING}`,
-  "7. Never accept or reject proposals, push saves, remove sources, or access vault values without explicit user approval.",
+  "4. Use the dedicated v0.7.0 tools for the proposal flow: `akm_proposal` (list/show/diff/accept/reject), `akm_reflect`, `akm_propose`, and `akm_distill`. Fall back to `akm_help` for any verb without a dedicated tool.",
+  "5. Treat `lesson:*` as first-class durable learning assets — they are produced by `akm_distill <ref>` as proposals and accepted via `akm_proposal action=accept`.",
+  "6. Run `akm_setup` once on a fresh machine to detect installed agent CLIs and persist `agent.default`. Reflect/propose require it.",
+  `7. ${PROPOSED_QUALITY_WARNING}`,
+  "8. Never accept or reject proposals, push saves, remove sources, or access vault values without explicit user approval.",
 ].join("\n")
 
 function readPackageVersion(): string {
@@ -2952,6 +2953,89 @@ export const AkmPlugin: Plugin = async ({ client, worktree, directory }) => {
             return runCli(client as unknown as LogCapableClient, ["workflow", "resume", run_id], logMeta)
           }
         }
+      },
+    }),
+    akm_proposal: tool({
+      description: "Operate the AKM v0.7.0 proposal queue — list/show/diff/accept/reject pending drafts. All proposal-producing commands (reflect, propose, distill, plus plugin-emitted proposals) write through this queue. Acceptance runs full validation before promoting; rejection archives the draft. Always confirm with the user before action='accept' or 'reject'.",
+      args: {
+        action: tool.schema.enum(["list", "show", "diff", "accept", "reject"]).describe("Proposal subcommand."),
+        id: tool.schema.string().optional().describe("Proposal id. Required for show/diff/accept/reject."),
+        status: tool.schema.enum(["pending", "accepted", "rejected"]).optional().describe("Filter for action='list'."),
+        reason: tool.schema.string().optional().describe("Required for action='reject'. Recorded with the archived proposal."),
+      },
+      async execute({ action, id, status, reason }) {
+        const logMeta = { toolName: "akm_proposal" }
+        switch (action) {
+          case "list": {
+            const args = ["proposal", "list"]
+            if (status) args.push("--status", status)
+            return runCli(client as unknown as LogCapableClient, args, logMeta)
+          }
+          case "show": {
+            if (!id) return JSON.stringify({ ok: false, error: "'id' is required for action='show'." })
+            return runCli(client as unknown as LogCapableClient, ["proposal", "show", id], logMeta)
+          }
+          case "diff": {
+            if (!id) return JSON.stringify({ ok: false, error: "'id' is required for action='diff'." })
+            return runCli(client as unknown as LogCapableClient, ["proposal", "diff", id], logMeta)
+          }
+          case "accept": {
+            if (!id) return JSON.stringify({ ok: false, error: "'id' is required for action='accept'. Confirm with the user before accepting." })
+            return runCli(client as unknown as LogCapableClient, ["proposal", "accept", id], logMeta)
+          }
+          case "reject": {
+            if (!id) return JSON.stringify({ ok: false, error: "'id' is required for action='reject'. Confirm with the user before rejecting." })
+            if (!reason || !reason.trim()) return JSON.stringify({ ok: false, error: "'reason' is required for action='reject'. Ask the user why the proposal is being rejected." })
+            return runCli(client as unknown as LogCapableClient, ["proposal", "reject", id, "--reason", reason], logMeta)
+          }
+        }
+      },
+    }),
+    akm_reflect: tool({
+      description: "Generate a reflection proposal for an AKM ref via the configured agent CLI. Output lands in the proposal queue only — never mutates live stash content. Requires `agent.default` to be set (run akm_setup first if missing).",
+      args: {
+        ref: tool.schema.string().optional().describe("[origin//]type:name ref to reflect on. Optional — when omitted the agent reflects on overall session signal."),
+        task: tool.schema.string().optional().describe("Free-form task description guiding the reflection."),
+      },
+      async execute({ ref, task }) {
+        const args = ["reflect"]
+        if (ref) args.push(ref)
+        if (task) args.push("--task", task)
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_reflect" })
+      },
+    }),
+    akm_propose: tool({
+      description: "Generate a new-asset proposal via the configured agent CLI. The asset is drafted as `quality:\"proposed\"` and lands in the proposal queue — never directly into curated content. Requires `agent.default` (run akm_setup first if missing).",
+      args: {
+        type: tool.schema.enum(["skill", "command", "agent", "knowledge", "lesson", "script", "workflow", "wiki"]).describe("Asset type for the new proposal."),
+        name: tool.schema.string().describe("Slug for the new asset (matches the standard ref grammar)."),
+        task: tool.schema.string().describe("Required. Describes what the asset should do."),
+      },
+      async execute({ type, name, task }) {
+        if (!task || !task.trim()) return JSON.stringify({ ok: false, error: "'task' is required for akm_propose." })
+        const args = ["propose", type, name, "--task", task]
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_propose" })
+      },
+    }),
+    akm_distill: tool({
+      description: "Distill an AKM ref into a proposed `lesson` using the bounded in-tree LLM. Gated by `llm.features.feedback_distillation` (default false); when the gate is off the call returns a fallback warning instead of a proposal. Lessons require `description` and `when_to_use` frontmatter and are stored under `lessons/<name>.md` after acceptance.",
+      args: {
+        ref: tool.schema.string().describe("[origin//]type:name ref to distill — most often memory:<name> or knowledge:<name>."),
+      },
+      async execute({ ref }) {
+        if (!ref || !ref.trim()) return JSON.stringify({ ok: false, error: "'ref' is required for akm_distill." })
+        return runCli(client as unknown as LogCapableClient, ["distill", ref], { toolName: "akm_distill" })
+      },
+    }),
+    akm_setup: tool({
+      description: "Detect installed agent CLIs (opencode, claude, codex, gemini, aider) and persist `agent.default`. Required once per machine before akm_reflect / akm_propose can shell out. Idempotent — pass force=true to re-run detection even when agent.default is already set.",
+      args: {
+        force: tool.schema.boolean().optional().describe("Re-run detection even when agent.default is already configured."),
+      },
+      async execute({ force }) {
+        const args = ["setup"]
+        if (force) args.push("--force")
+        return runCli(client as unknown as LogCapableClient, args, { toolName: "akm_setup" })
       },
     }),
     akm_help: tool({

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "akm-opencode",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
-  "description": "OpenCode plugin for AKM - search, show, and manage extension assets via the akm CLI, including v0.5.0 vaults, wikis, and workflows, with agentic hooks that auto-load relevant stash assets, record feedback, and harvest session memories so the stash improves every session.",
+  "description": "OpenCode plugin for AKM v0.7.0 - search, show, and manage extension assets via the akm CLI, including vaults, wikis, workflows, the proposal queue, lesson assets, and reflect/propose/distill commands, with agentic hooks that auto-load relevant stash assets, record feedback, and harvest session memories so the stash improves every session.",
   "keywords": [
     "opencode",
     "opencode-ai",

--- a/tests/claude-plugin.test.ts
+++ b/tests/claude-plugin.test.ts
@@ -122,6 +122,12 @@ describe("Claude plugin metadata", () => {
       "akm-wiki",
       "akm-workflow",
       "akm-vault",
+      "akm-proposal",
+      "akm-review-proposals",
+      "akm-reflect",
+      "akm-propose",
+      "akm-distill",
+      "akm-setup",
       "akm-help",
     ]) {
       const file = path.join(commandsDir, `${name}.md`)
@@ -131,6 +137,26 @@ describe("Claude plugin metadata", () => {
     expect(existsSync(path.join(commandsDir, "akm-save.md"))).toBe(false)
     expect(existsSync(path.join(commandsDir, "akm-add.md"))).toBe(false)
     expect(existsSync(path.join(agentsDir, "akm-curator.md"))).toBe(true)
+  })
+
+  it("v0.7.0 slash commands carry the canonical proposal-flow guard rails", () => {
+    const commandsDir = path.join(repoRoot, "claude/commands")
+    const proposal = readFileSync(path.join(commandsDir, "akm-proposal.md"), "utf8")
+    expect(proposal).toContain("proposal list")
+    expect(proposal).toContain("proposal accept")
+    expect(proposal).toContain("proposal reject")
+    expect(proposal).toMatch(/[Cc]onfirm with the user/)
+
+    const review = readFileSync(path.join(commandsDir, "akm-review-proposals.md"), "utf8")
+    expect(review).toContain("proposal list --status pending")
+    expect(review).toMatch(/[Dd]o not call `?akm proposal accept/)
+
+    const distill = readFileSync(path.join(commandsDir, "akm-distill.md"), "utf8")
+    expect(distill).toContain("llm.features.feedback_distillation")
+    expect(distill).toContain("distill <ref>")
+
+    const setup = readFileSync(path.join(commandsDir, "akm-setup.md"), "utf8")
+    expect(setup).toContain("agent.default")
   })
 
   it("keeps the curated akm_help registry table in parity across embeds", () => {
@@ -577,6 +603,112 @@ exit 0
     const recorded = readFileSync(feedbackLog, "utf8")
     expect(recorded).toContain("feedback command:release --negative")
     expect(recorded).not.toContain("feedback memory:notes")
+  })
+
+  it("post-tool recognizes lesson:* refs (v0.7.0)", () => {
+    const tempDir = makeTempDir()
+    const stateDir = path.join(tempDir, "state")
+    mkdirSync(stateDir, { recursive: true })
+
+    runHook(["post-tool", "success"], {
+      input: JSON.stringify({
+        tool: "Bash",
+        session_id: "sess-lesson-1",
+        input: { command: "akm show lesson:rollback-pattern" },
+        output: "{\"type\":\"lesson\",\"ref\":\"lesson:rollback-pattern\"}",
+      }),
+      env: {
+        HOME: tempDir,
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        XDG_STATE_HOME: stateDir,
+      },
+    })
+
+    expect(getFirstLogEntry(stateDir, "memory.log")).toContain("lesson:rollback-pattern")
+  })
+
+  it("auto-feedback skips lesson:* refs (v0.7.0)", () => {
+    const tempDir = makeTempDir()
+    const binDir = path.join(tempDir, "bin")
+    const stateDir = path.join(tempDir, "state")
+    const feedbackLog = path.join(tempDir, "akm-feedback.log")
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(stateDir, { recursive: true })
+    const quotedLog = shellQuote(feedbackLog)
+
+    writeFileSync(
+      path.join(binDir, "akm"),
+      `#!/usr/bin/env sh
+printf '%s\\n' "$*" >> ${quotedLog}
+exit 0
+`,
+    )
+    chmodSync(path.join(binDir, "akm"), 0o755)
+
+    runHook(["auto-feedback", "success"], {
+      input: JSON.stringify({
+        tool: "Bash",
+        input: { command: "akm show lesson:rollback-pattern" },
+        output: "{\"type\":\"lesson\",\"ref\":\"lesson:rollback-pattern\"}",
+      }),
+      env: {
+        HOME: tempDir,
+        PATH: `${binDir}:/usr/bin:/bin`,
+        XDG_STATE_HOME: stateDir,
+      },
+    })
+
+    const recorded = existsSync(feedbackLog) ? readFileSync(feedbackLog, "utf8") : ""
+    expect(recorded).not.toContain("feedback lesson:rollback-pattern")
+  })
+
+  it("auto-feedback skips proposed-quality refs (v0.7.0)", () => {
+    const tempDir = makeTempDir()
+    const binDir = path.join(tempDir, "bin")
+    const stateDir = path.join(tempDir, "state")
+    const callLog = path.join(tempDir, "akm-calls.log")
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(stateDir, { recursive: true })
+    const quotedLog = shellQuote(callLog)
+
+    // Fake akm: when asked to `show <ref>`, return a JSON body with
+    // quality:"proposed". Record every invocation so we can confirm no
+    // feedback call was made.
+    writeFileSync(
+      path.join(binDir, "akm"),
+      `#!/usr/bin/env sh
+printf '%s\\n' "$*" >> ${quotedLog}
+case "$*" in
+  *show*skill:draft-rollback*)
+    echo '{"type":"skill","ref":"skill:draft-rollback","quality":"proposed"}'
+    exit 0
+    ;;
+esac
+exit 0
+`,
+    )
+    chmodSync(path.join(binDir, "akm"), 0o755)
+
+    runHook(["auto-feedback", "success"], {
+      input: JSON.stringify({
+        tool: "Bash",
+        input: { command: "akm show skill:draft-rollback" },
+        output: "{\"type\":\"skill\",\"ref\":\"skill:draft-rollback\",\"quality\":\"proposed\"}",
+      }),
+      env: {
+        HOME: tempDir,
+        PATH: `${binDir}:/usr/bin:/bin`,
+        XDG_STATE_HOME: stateDir,
+      },
+    })
+
+    const calls = readFileSync(callLog, "utf8")
+    // The probe call must have happened, but no feedback call should follow.
+    expect(calls).toContain("show skill:draft-rollback")
+    expect(calls).not.toContain("feedback skill:draft-rollback")
+
+    const skipLog = readLogLines(path.join(stateDir, "akm-claude/feedback.log"))
+    expect(skipLog.some((line) => line.includes("skip_proposed\tskill:draft-rollback"))).toBe(true)
   })
 
   it("auto-feedback is a no-op when the command did not invoke akm", () => {

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -124,7 +124,7 @@ describe("akm-opencode plugin", () => {
       expect(hooks.tool).toBeDefined()
     })
 
-    it("registers the trimmed high-value tool surface plus akm_help", async () => {
+    it("registers the high-value tool surface plus akm_help and the v0.7.0 proposal/lesson tools", async () => {
       const hooks = await AkmPlugin(createPluginInput())
       const toolNames = Object.keys(hooks.tool!)
       const expected = [
@@ -141,6 +141,11 @@ describe("akm-opencode plugin", () => {
         "akm_vault",
         "akm_wiki",
         "akm_workflow",
+        "akm_proposal",
+        "akm_reflect",
+        "akm_propose",
+        "akm_distill",
+        "akm_setup",
         "akm_help",
       ]
       for (const name of expected) {
@@ -307,6 +312,42 @@ describe("akm-opencode plugin", () => {
       expect(wf.args.reset).toBeDefined()
       expect(wf.args.filter_ref).toBeDefined()
       expect(wf.args.active_only).toBeDefined()
+    })
+
+    it("akm_proposal exposes the v0.7.0 list/show/diff/accept/reject discriminator", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const tool = hooks.tool!.akm_proposal
+      expect(tool.args.action).toBeDefined()
+      expect(tool.args.id).toBeDefined()
+      expect(tool.args.status).toBeDefined()
+      expect(tool.args.reason).toBeDefined()
+    })
+
+    it("akm_reflect exposes ref + task args", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const tool = hooks.tool!.akm_reflect
+      expect(tool.args.ref).toBeDefined()
+      expect(tool.args.task).toBeDefined()
+    })
+
+    it("akm_propose requires type/name/task", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const tool = hooks.tool!.akm_propose
+      expect(tool.args.type).toBeDefined()
+      expect(tool.args.name).toBeDefined()
+      expect(tool.args.task).toBeDefined()
+    })
+
+    it("akm_distill takes a ref", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const tool = hooks.tool!.akm_distill
+      expect(tool.args.ref).toBeDefined()
+    })
+
+    it("akm_setup exposes the force flag", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const tool = hooks.tool!.akm_setup
+      expect(tool.args.force).toBeDefined()
     })
 
   })
@@ -2097,6 +2138,132 @@ describe("akm-opencode plugin", () => {
       expect(parsed.ok).toBe(true)
       expect(parsed.ref).toBe("command:review.md")
       expect(parsed.usedSubtask).toBe(true)
+    })
+
+    it("akm_proposal list shells out to `akm proposal list`", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockReturnValue("{\"proposals\":[]}")
+      await hooks.tool!.akm_proposal.execute(
+        { action: "list" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["proposal", "list", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_proposal list forwards a status filter", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockReturnValue("{\"proposals\":[]}")
+      await hooks.tool!.akm_proposal.execute(
+        { action: "list", status: "pending" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["proposal", "list", "--status", "pending", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_proposal show requires an id", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const result = await hooks.tool!.akm_proposal.execute(
+        { action: "show" } as any,
+        {} as any,
+      )
+      const parsed = JSON.parse(result)
+      expect(parsed.ok).toBe(false)
+      expect(parsed.error).toContain("'id' is required")
+    })
+
+    it("akm_proposal accept routes through the runCli approval pathway", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockReturnValue("{\"ok\":true}")
+      await hooks.tool!.akm_proposal.execute(
+        { action: "accept", id: "p_123" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["proposal", "accept", "p_123", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_proposal reject requires a reason", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const result = await hooks.tool!.akm_proposal.execute(
+        { action: "reject", id: "p_123" } as any,
+        {} as any,
+      )
+      const parsed = JSON.parse(result)
+      expect(parsed.ok).toBe(false)
+      expect(parsed.error).toContain("'reason' is required")
+    })
+
+    it("akm_reflect forwards ref + task", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockReturnValue("{\"ok\":true}")
+      await hooks.tool!.akm_reflect.execute(
+        { ref: "knowledge:design", task: "review consistency" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["reflect", "knowledge:design", "--task", "review consistency", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_propose requires task and forwards type/name/task", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockReturnValue("{\"ok\":true}")
+      const noTask = await hooks.tool!.akm_propose.execute(
+        { type: "skill", name: "release-checks" } as any,
+        {} as any,
+      )
+      expect(JSON.parse(noTask).ok).toBe(false)
+
+      await hooks.tool!.akm_propose.execute(
+        { type: "skill", name: "release-checks", task: "fail loudly when CI is red" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["propose", "skill", "release-checks", "--task", "fail loudly when CI is red", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_distill requires a ref", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      const missing = await hooks.tool!.akm_distill.execute({} as any, {} as any)
+      expect(JSON.parse(missing).ok).toBe(false)
+
+      mockExecFileSync.mockReturnValue("{\"ok\":true}")
+      await hooks.tool!.akm_distill.execute(
+        { ref: "memory:retro" } as any,
+        {} as any,
+      )
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["distill", "memory:retro", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
+    })
+
+    it("akm_setup runs `akm setup` and threads --force", async () => {
+      const hooks = await AkmPlugin(createPluginInput())
+      mockExecFileSync.mockReturnValue("{\"ok\":true}")
+      await hooks.tool!.akm_setup.execute({ force: true } as any, {} as any)
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "akm",
+        ["setup", "--force", "--format", "json"],
+        expect.objectContaining({ encoding: "utf8" }),
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

This PR adds support for AKM v0.7.0 features across both Claude and OpenCode plugins, introducing the proposal queue workflow, lesson asset type, and agent CLI integration.

## Key Changes

### Proposal Queue & New Asset Type
- Added `akm_proposal` tool (OpenCode) and `/akm-proposal` command (Claude) to operate the v0.7.0 proposal queue with `list`, `show`, `diff`, `accept`, and `reject` actions
- Added `lesson` as a first-class asset type alongside existing types (skill, command, agent, knowledge, memory, script, workflow, vault, wiki)
- Updated ref pattern matching to recognize `lesson:*` refs in both hook scripts and plugin code
- Added quality classification support (`curated`, `generated`, `proposed`) with automatic filtering of proposed assets from default search

### Agent CLI Integration
- Added `akm_setup` tool to detect and persist `agent.default` configuration
- Added `akm_reflect` tool to generate reflection proposals via configured agent CLI
- Added `akm_propose` tool to generate new-asset proposals via configured agent CLI
- Added `akm_distill` tool to distill refs into lesson proposals using bounded in-tree LLM (gated by `llm.features.feedback_distillation`)
- Added `akm_review_proposals` command (Claude) to batch-review pending proposals

### Hook & Feedback Improvements
- Updated `auto-feedback` hook to skip `lesson:*` refs and `proposed`-quality assets (they route through proposal queue instead)
- Added `ref_quality()` function to resolve asset quality with caching to avoid repeated CLI calls
- Added `detect_agent_default()` function to auto-run `akm setup` once per machine on session start
- Added pending proposal summary to session start output
- Updated session start footer to mention new v0.7.0 commands and proposal queue

### Configuration & Environment
- Made `AKM_PACKAGE_REF` environment variable configurable (defaults to `akm-cli@latest`)
- Added new state directory files: `quality-cache.tsv` and `setup.stamp`
- Added `AUTO_SETUP` environment variable (defaults to `1`)

### Documentation & Tests
- Updated skill description and README files to reflect v0.7.0 capabilities
- Added comprehensive test coverage for all new tools and proposal queue operations
- Added tests for lesson ref recognition and proposed-quality feedback skipping
- Updated command metadata tests to verify new slash commands exist with proper guard rails

## Implementation Details

- Proposal operations shell out to `akm proposal <action>` with `--format json` for structured responses
- Quality caching prevents redundant `akm show` calls within a single hook process
- Auto-feedback intelligently skips proposed assets by checking quality before attempting feedback
- Agent CLI detection runs once per machine (guarded by `setup.stamp`) unless forced via `AKM_AUTO_SETUP=force`
- All new tools include proper validation (e.g., requiring `id` for show/diff/accept, `reason` for reject)
- Proposal acceptance/rejection require explicit user confirmation in Claude commands

## Version Bump

Both `akm-claude` and `akm-opencode` packages bumped from 0.6.0 to 0.7.0 to align with AKM CLI v0.7.0.

https://claude.ai/code/session_01Edhp8HNt66Z9sLEn6Ci99n